### PR TITLE
Add syntax highlighting to codeblocks

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,7 +90,7 @@ See the latest [Release Notes](https://github.com/ldn-softdev/jtc/blob/master/Re
 *run `jtc -g` for walk path explanations, usage notes and additional usage examples*
 
 Consider a following JSON (a mockup of a bookmark container), stored in a file `Bookmarks`:
-```
+``` json
 {
    "Bookmarks": [
       {
@@ -148,7 +148,7 @@ Consider a following JSON (a mockup of a bookmark container), stored in a file `
 
 
 ### 1. let's start with a simple thing - list all URLs:
-```
+``` ShellSession
 bash $ jtc -w'<url>l:' Bookmarks
 "https://www.nytimes.com/"
 "https://www.huffingtonpost.co.uk/"
@@ -168,7 +168,7 @@ let's take a look at the walk-path `<url>l:`:
 
 
 ### 2. dump all bookmark names from the `Work` folder:
-```
+``` ShellSession
 bash $ jtc -w'<Work>[-1][children][:][name]' Bookmarks
 "Stack Overflow"
 "C++ reference"
@@ -199,11 +199,11 @@ _*** there's more on offsets and search quantifiers below_
 in order to understand better how a walk path works, let's run a series of cli in a slow-motion, gradually adding lexemes
 to the path, perhaps with the option `-l` to see also the labels (if any) of the selected elements:
 
-```
+``` ShellSession
 bash $ jtc -w'<Work>' -l Bookmarks
 "name": "Work"
 ```
-```
+``` ShellSession
 bash $ jtc -w'<Work>[-1]' -l Bookmarks
 {
    "children": [
@@ -222,7 +222,7 @@ bash $ jtc -w'<Work>[-1]' -l Bookmarks
    "stamp": "2018-03-06, 12:07:29"
 }
 ```
-```
+``` ShellSession
 bash $ jtc -w'<Work>[-1][children]' -l Bookmarks
 "children": [
    {
@@ -237,7 +237,7 @@ bash $ jtc -w'<Work>[-1][children]' -l Bookmarks
    }
 ]
 ```
-```
+``` ShellSession
 bash $ jtc -w'<Work>[-1][children][:]' -l Bookmarks
 {
    "name": "Stack Overflow",
@@ -250,7 +250,7 @@ bash $ jtc -w'<Work>[-1][children][:]' -l Bookmarks
    "url": "https://en.cppreference.com/"
 }
 ```
-```
+``` ShellSession
 bash $ jtc -w'<Work>[-1][children][:][name]' -l Bookmarks
 "name": "Stack Overflow"
 "name": "C++ reference"
@@ -258,7 +258,7 @@ bash $ jtc -w'<Work>[-1][children][:][name]' -l Bookmarks
 
 
 ### 3. dump all URL's names:
-```
+``` ShellSession
 bash $ jtc -w'<url>l:[-1][name]' Bookmarks
 "The New York Times"
 "HuffPost UK"
@@ -276,7 +276,7 @@ this walk path `<url>l:[-1][name]`:
 
 
 ### 4. dump all the URLs and their corresponding names, preferably wrap found pairs in JSON:
-```
+``` ShellSession
 bash $ jtc -w'<url>l:' -w'<url>l:[-1][name]' -jl Bookmarks
 [
    {
@@ -339,13 +339,13 @@ for the detailed explanation of the subscripts, search lexemes and directives.
 `jtc` is extensively debuggable: the more times option `-d` is given the more debugs will be produced (currently debug depth may go
 as deep as 7: `-ddddddd`).
 Enabling too many debugs might be overwhelming, though one specific case many would find extremely useful - when validating a failing JSON:
-```
-bash $ <addressbook-sampe.json jtc 
+``` ShellSession
+bash $ <addressbook-sampe.json jtc
 jtc json exception: expected_json_value
 ```
 If JSON is big, it's desirable to locate the parsing failure point. Specifying just one `-d` let easily spotting the
 parsing failure point and its locus:
-```
+``` ShellSession
 bash $ <addressbook-sampe.json jtc -d
 .read_inputs(), reading json from <stdin>
 .parsejson(), exception locus: ...       ],|       "children": [,],|       "spouse": null|    }...
@@ -365,7 +365,7 @@ Say, we want to accomplish a following task:
 3. output resulting Address Book JSON
 
 Below is the code sample how that could be achieved using `Json.hpp` class and the source JSON - Address Book:
-```
+``` C++
 #include <iostream>
 #include <fstream>
 #include "lib/Json.hpp"
@@ -388,7 +388,7 @@ int main(int argc, char *argv[]) {
 ```
 
 Address Book JSON:
-```
+``` ShellSession
 bash $ cat addressbook-sample.json
 {
   "AddressBook": [
@@ -456,7 +456,7 @@ bash $
 ```
 
 Output result:
-```
+``` ShellSession
 bash$ cat addressbook-sample.json | sort_ab
 [
    [
@@ -592,8 +592,8 @@ _Parsing result_ | `[ 0.00001 ]` | `[1e-05]`
 
 ### performance:
 here's a 4+ million node JSON [test file](https://github.com/ldn-softdev/jtc/releases/download/standard.json/standard.json):
-```
-bash $ jtc -zz standard.json 
+``` ShellSession
+bash $ jtc -zz standard.json
 4329975
 ```
 The table below compares `jtc` and jq performance for similar operations (using `TIMEFORMAT="user %U sec"`,

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # `jtc` - cli tool to extract, manipulate and transform source JSON
 
-`jtc` stand for: _JSON test console_, but it's a legacy name, don't get misled.  
-  
+`jtc` stand for: _JSON test console_, but it's a legacy name, don't get misled.
+
 `jtc` offers a powerful way to select one or multiple elements from a source JSON and apply various actions on the selected elements
 at once (wrap selected elements into a new JSON, filter in/out, update elements, insert new elements, remove, copy, move, compare,
 transform and swap around).
@@ -33,7 +33,7 @@ transform and swap around).
   - support Regular Expressions when searching source JSON
   - fast and efficient processing very large JSON files (built-in search cache)
   - insert/updates operations optionally may undergo _shell cli_ evaluation
-  - features namespaces, interpolation from namespaces and templates 
+  - features namespaces, interpolation from namespaces and templates
   - supports buffered and streamed modes of input reads
   - written entirely in C++14, no dependencies (STL only, idiomatic C++, no memory leaks)
   - extensively debuggable
@@ -52,9 +52,9 @@ paths. See below more detailed explanation with examples
 ### Linux and MacOS precompiled binaries are available for download
 
 For compiling, `c++14` (or later) is required:
-  - to compile under MacOS, use cli:  
+  - to compile under MacOS, use cli:
       `c++ -o jtc -Wall -std=c++14 -Ofast jtc.cpp`
-  - To compile under Linux, use cli:  
+  - To compile under Linux, use cli:
       `c++ -o jtc -Wall -std=gnu++14 -static -Ofast jtc.cpp`
 
 *pass `-DNDEBUG` flag if you like to compile w/o debugs, however it's unadvisable -
@@ -175,11 +175,11 @@ bash $ jtc -w'<Work>[-1][children][:][name]' Bookmarks
 ```
 here the walk path `<Work>[-1][children][:][name]` is made of following lexemes (spaces separating lexemes are optional):
 
-a. `<Work>`: find within a JSON tree the **first** occurrence where the **JSON string** value is matching `"Work"` exactly  
-b. `[-1]`: **step up** one tier in the JSON tree structure (i.e. address an immediate parent of the found JSON element)  
-c. `[children]`: **select/address** a node whose label is `"children"` (it'll be a JSON array, at the same tier with `Work`)  
-d. `[:]`: select an **each node** in the array  
-e. `[name]`: select/address a node whose label is `"name"`  
+a. `<Work>`: find within a JSON tree the **first** occurrence where the **JSON string** value is matching `"Work"` exactly
+b. `[-1]`: **step up** one tier in the JSON tree structure (i.e. address an immediate parent of the found JSON element)
+c. `[children]`: **select/address** a node whose label is `"children"` (it'll be a JSON array, at the same tier with `Work`)
+d. `[:]`: select an **each node** in the array
+e. `[name]`: select/address a node whose label is `"name"`
 
 - subscript offsets are enclosed into square brackets `[`, `]` and may have different meaning:
   * simple numerical offsets (e.g.: `[0]`, `[5]`, etc) select/address a respective JSON immediate child in the addressed
@@ -312,17 +312,17 @@ bash $ jtc -w'<url>l:' -w'<url>l:[-1][name]' -jl Bookmarks
 In short:
 - Subscript lexemes (`[..]`) facilitate:
     - addressing children (by index/label) in _JSON iterables_ (_arrays_ and _objects_) - i.e. traverse JSON structure downward
-    from the root (toward leaves), e.g.: `[2]`, `[id]` 
+    from the root (toward leaves), e.g.: `[2]`, `[id]`
     - addressing parents (immediate and distant) - i.e. traverse JSON structure upwards, toward the the root (from leaves),
     e.g.:  `[-1]` (tier offset from the walked element), `[^2]` (tier offset from the root)
-    - select ranges and slices of JSON elements in _JSON iterables_, e.g.: `[+2]`, `[:]`, `[:3]`, `[-2:]`, `[1:-1]` 
+    - select ranges and slices of JSON elements in _JSON iterables_, e.g.: `[+2]`, `[:]`, `[:3]`, `[-2:]`, `[1:-1]`
 - Search lexemes (`<..>`, `>..<`) facilitate:
     - recursive (`<..>`) and non-recursive (`>..<`) matches
-    - there're optional one-letter suffixes that may follow the lexemes (e.g.: `<..>Q`) which define type of search: (REGEX) string 
-    search, (REGEX) label search, (REGEX) numerical, boolean, null, atomic, objects, arrays (or either), arbitrary JSONs, 
+    - there're optional one-letter suffixes that may follow the lexemes (e.g.: `<..>Q`) which define type of search: (REGEX) string
+    search, (REGEX) label search, (REGEX) numerical, boolean, null, atomic, objects, arrays (or either), arbitrary JSONs,
     unique, duplicates, etc.
     - there're also optional quantifiers to lexemes (must take the last position, after the suffix if one present) - let selecting
-    match instance, or range of matches (e.g.: `<id>l3`- will match 4th (zero based) label `"id"`; if no quantifier present `0` 
+    match instance, or range of matches (e.g.: `<id>l3`- will match 4th (zero based) label `"id"`; if no quantifier present `0`
     is assumed - first match)
 - subscript lexemes could be joined with search lexemes over ':' to facilitate _scoped search_, e.g.: `[id]:<value>` is a single
    lexeme which will match recursively the first occurrence of the string `"value"` with the label `"id"` - i.e. `"id": "value"`
@@ -331,7 +331,7 @@ In short:
     like: memorize it in the _namespace_, or erase from it, or memorize its label, or perform a _shell cli_ evaluation
     - couple directives (`<>f` and `<>F`) facilitate also walk branching
 
-Refer to 
+Refer to
 [`jtc` User Guide](https://github.com/ldn-softdev/jtc/blob/master/User%20Guide.md#walking-json)
 for the detailed explanation of the subscripts, search lexemes and directives.
 
@@ -351,7 +351,7 @@ bash $ <addressbook-sampe.json jtc -d
 .parsejson(), exception locus: ...       ],|       "children": [,],|       "spouse": null|    }...
 .location_(), exception spot: --------------------------------->| (offset: 967)
 jtc json exception: expected_json_value
-bash $ 
+bash $
 ```
 
 ## Complete User Guide
@@ -526,7 +526,7 @@ for the complete description of Json class interface, refer to [Json.hpp](https:
 
 
 ## `jtc` vs **jq**:
-`jtc` was _inspired_ by the complexity of **jq** interface (and its 
+`jtc` was _inspired_ by the complexity of **jq** interface (and its
 [DSL](https://en.wikipedia.org/wiki/Domain-specific_language)),
 aiming to provide a user tool which would let attaining the desired result in a more feasible way
 
@@ -536,21 +536,21 @@ aiming to provide a user tool which would let attaining the desired result in a 
  performs one operation at a time and if successive operations required, then _cli_ to be daisy-chained over the pipe symbol `|`
 
 **jq** is non-idiomatic in a _unix way_, e.g., one can write a program in **jq** language that even has nothing to do with JSON.
-Most of the requests (if not all) to manipulate JSONs are _ad hoc_ type of tasks, and learning **jq**'s DSL for _ad hoc_ type of tasks 
+Most of the requests (if not all) to manipulate JSONs are _ad hoc_ type of tasks, and learning **jq**'s DSL for _ad hoc_ type of tasks
 is an overkill (that purpose is best facilitated with
-[GPL](https://en.wikipedia.org/wiki/General-purpose_language)).  
+[GPL](https://en.wikipedia.org/wiki/General-purpose_language)).
 The number of asks on the
-[stackoverflow](https://stackoverflow.com/) 
-to facilitate even simple queries for **jq** is huge - that's the proof in itself that for many people feasibility of attaining their 
+[stackoverflow](https://stackoverflow.com/)
+to facilitate even simple queries for **jq** is huge - that's the proof in itself that for many people feasibility of attaining their
 asks with **jq** is a way too low, hence they default to posting their questions on the forum.
 
 `jtc` on the other hand is a utility (not a language), which employs a novel but powerful concept, which "embeds" the ask right into the
-_walk-path_. That facilitates a much higher feasibility of attaining a desired result: building the walk-path a lexeme by a lexeme, 
+_walk-path_. That facilitates a much higher feasibility of attaining a desired result: building the walk-path a lexeme by a lexeme,
 one at a time, provides an immediate visual feedback and let coming up with the desired result quite quickly.
 
 ### learning curve:
- - **jq**: before you could come up with a query to handle even a relatively simple ask, you need to become an expert in 
- **jq**'s language, which will take some time. Coming up with the complex queries requires it seems having a "PhD" in **jq**, or spending 
+ - **jq**: before you could come up with a query to handle even a relatively simple ask, you need to become an expert in
+ **jq**'s language, which will take some time. Coming up with the complex queries requires it seems having a "PhD" in **jq**, or spending
  lots of time on stackoverflow and similar forums
  - `jtc` employs only a single (but powerful) concept of the _walk-path_ (which is made only of 2 types of lexemes,
  each type though has several variants) which is easy to grasp.
@@ -559,28 +559,28 @@ one at a time, provides an immediate visual feedback and let coming up with the 
  - **jq**: handling irregular JSONs for **jq** is not a challenge, building a query is! The more irregularities you need
  to handle the more challenging the query (**jq** program) becomes
  - `jtc` was conceived with the idea of being capable of handling complex irregular JSONs with a simplified interface - that all is
- fitted into the concept of the _walk-path_, while daisy-chaining multiple `jtc` operations it's possible to satisfy almost every query. 
+ fitted into the concept of the _walk-path_, while daisy-chaining multiple `jtc` operations it's possible to satisfy almost every query.
 
 
 ### programming model
  - **jq** is written in _C_, which drags all intrinsic problems the language has dated its creation
  - `jtc` is written in idiomatic _C++_ (the most powerful programming language to date) using STL only.
  Main JSON engine/library does not have a single `new` operator,
- nor it has a single naked pointer acting as a resource holder/owner, thus `jtc` is guaranteed to be **free of memory leaks** 
- (at least one class of the problems is off the table) - **STL guaranty**.  
+ nor it has a single naked pointer acting as a resource holder/owner, thus `jtc` is guaranteed to be **free of memory leaks**
+ (at least one class of the problems is off the table) - **STL guaranty**.
  Also, `jtc` is written in a very portable way, it should not cause any problems compiling it under any unix like system.
 
 
 ### JSON numerical fidelity:
- - **jq** is not compliant with JSON numerical definition. What jq does, it simply converts a symbolic numerical representation to an 
+ - **jq** is not compliant with JSON numerical definition. What jq does, it simply converts a symbolic numerical representation to an
  internal binary and keeps it that way. That approach:
      - is not compliant with JSON definition of the numerical values
      - it has problems retaining required precision
      - might change original representation of numericals
  - `jtc` validates all JSON numericals per JSON standard and keep numbers internally in their original symbolical format, so it's free of
  all the above caveats:
- 
- Handling | `jtc` | **jq** 
+
+ Handling | `jtc` | **jq**
  --- | ---: | :---
 Invalid Json: `[ 00 ]` | `<<<'[00]' jtc` | `<<<'[00]' jq -c .`
 _Parsing result_ | `jtc json exception: missed_prior_enumeration` | `[0]`
@@ -627,8 +627,3 @@ The computer's spec used for tests:
 Refer to a complete [User Guide](https://github.com/ldn-softdev/jtc/blob/master/User%20Guide.md) for further examples and guidelines.
 
 ##### Enhancement requests are more than welcome: *ldn.softdev@gmail.com*
-
-
-
-
-

--- a/Release Notes.md
+++ b/Release Notes.md
@@ -6,18 +6,18 @@ _Release Notes for `jtc` v.1.74_
 
 
 #### Improvements, changes, fixes:
-- improved handling of `<>q` and `<>Q` lexemes drastically (performance and memory utilization-wise), 
+- improved handling of `<>q` and `<>Q` lexemes drastically (performance and memory utilization-wise),
 also now those lexemes may be empty (before it was mandatory to give a namespace in the lexemes)
-- option `-t` now can be used to control spacing for the compact (one-row) view, e.g.: `-r -t0` will print a very compact one-liner JSON, 
+- option `-t` now can be used to control spacing for the compact (one-row) view, e.g.: `-r -t0` will print a very compact one-liner JSON,
 w/o spaces; when used together (`-r` and `-t`), it will also control spacing in stringification of JSON in template operations
-- introduced a support for _flags_ in _Regular Expressions_ (namely: `INOCESXAGP`); flags can be given only as trailing part of the RE 
-(they will be removed from the RE itself after parsing), e.g.: `<...\I\O>R:`; also, flags `ESXAGP` facilitate various REGEX grammars, 
+- introduced a support for _flags_ in _Regular Expressions_ (namely: `INOCESXAGP`); flags can be given only as trailing part of the RE
+(they will be removed from the RE itself after parsing), e.g.: `<...\I\O>R:`; also, flags `ESXAGP` facilitate various REGEX grammars,
 those flags will be processed only once (i.e., only the first setup grammar flag will have an effect, all subsequent will be ignored)
 - enhanced behavior of empty `<>k` lexeme - now it also has an effect when placed in front `><F` lexeme (i.e. logical end of walking),
 not only at the syntactical end of the walk-path
 - enhanced interpolation behavior of `{}` token: when interpolation of a _JSON object_ fails, it will be re-attempted to strip the
 _JSON object_ as an _array_  - effectively allowing conversion of _JSON objects_ into _JSON arrays_ in templates.
-- fixed an issue when a _"move"_ - semantic (`-p`) applied to _update (`-u`)_/_insert (`-i`)_ operations: 
+- fixed an issue when a _"move"_ - semantic (`-p`) applied to _update (`-u`)_/_insert (`-i`)_ operations:
 if the walks of the latter fails entirely then a _purge_ should not be applied on destination walks (UT'ed)
 ***
 
@@ -29,7 +29,7 @@ _Release Notes for `jtc` v.1.73_
 
 
 #### Improvements, changes, fixes:
-- lifted _label update_ operation when `-u` is used to update a label (when a walk-path is ending with an empty `...<>k` lexeme): 
+- lifted _label update_ operation when `-u` is used to update a label (when a walk-path is ending with an empty `...<>k` lexeme):
 now it's possible to update/rewrite recursively even nested labels w/o failures
 - converted walking (walk iteration) to a non-recursive loop, now walks are virtually endless (i.e. able to walk JSONs of virtually
 ANY size and depth) and not restricted by a depth of a stack
@@ -39,10 +39,10 @@ templates are interpolated per walks now (if a count of templates and walks matc
 - fixed insertion (`-i`) when the last lexeme of a walk is non-empty `<..>k` then no _label reinterpretation_ occurs
 (so it's consistent now with the same behavior of `-u`)
 - removed support for the empty `<>z` notation form of the lexeme: erasing entire _namespace_ is idiomatically inconsistent with the
-_walk design_ (and might lead to confusion or misunderstanding of the expected behavior), so only non-empty lexemes `<..>z` are 
+_walk design_ (and might lead to confusion or misunderstanding of the expected behavior), so only non-empty lexemes `<..>z` are
 supported now (and restricted to)
 - fixed a crash when debugging is on (quite a corner case though)
-- fixed a programmatic error (rarely occurs only in API calls) where Json class would falsely expect `<stdin>` in the event when 
+- fixed a programmatic error (rarely occurs only in API calls) where Json class would falsely expect `<stdin>` in the event when
    parsing constructor throws
 ***
 
@@ -51,7 +51,7 @@ _Release Notes for `jtc` v.1.72_
 
 #### New features:
 - introduced a new directive `<>I` which let incrementing/decrementing numerical JSONs preserved in the namespace (and ignore other
-JSON types), e.g.: `<var>I3`, `<var>I-1`. If `var` wasn't defined before, the iteration begins with `0`; 
+JSON types), e.g.: `<var>I3`, `<var>I-1`. If `var` wasn't defined before, the iteration begins with `0`;
 however, it's possible to initialize it with other than `0` values - see
 [User Guide](https://github.com/ldn-softdev/jtc/blob/master/User%20Guide.md#counting-with-jtc)
 - introduced an auto-namespace variable `$?` to reference the last processed walk, this facilitates use-cases when converting
@@ -61,32 +61,32 @@ for more
 - introduced new lexemes `<..>P`, `<..>N` to match any _JSON strings_ and _JSON numerical_ types respectively. Before, to facilitate the
 same, REGEX lexemes were used: `<.*>R` and `<.*>D` respectively, but new lexemes work faster and allow capturing matched values in
 the namespace)
-- Template-interpolation was enhanced with new capability to _jsonize JSON strings_ (containing embedded JSONs) and _stringify JSONs_ - 
+- Template-interpolation was enhanced with new capability to _jsonize JSON strings_ (containing embedded JSONs) and _stringify JSONs_ -
 similar to respective options `-qq` and `-rr` but now programmatically. See
 [User Guide](https://github.com/ldn-softdev/jtc/blob/master/User%20Guide.md#stringifying-json-jsonizing-stringified)
 for the syntax and examples
-- added a new semantic to `-x` option: `-xn[/N]` notation lets specifying a frequency of walks to be displayed - (every `n`th walk) 
+- added a new semantic to `-x` option: `-xn[/N]` notation lets specifying a frequency of walks to be displayed - (every `n`th walk)
 staring from the optional offset `N` (zero based); e.g.: `-x4` - display every _4th_ walk, while `-x4/1` will do the same starting
 from the 2nd (`N` index is zero based) walk.
-Also, note a special notation case: `-x0/N` - will display `Nth` (zero based) walk only _once_, this could be truncated to `-x/N`; 
+Also, note a special notation case: `-x0/N` - will display `Nth` (zero based) walk only _once_, this could be truncated to `-x/N`;
 `N` is positive, but also supported `-1` value - to display _the last_ walk
 
 #### Improvements, changes, fixes:
-- improved `-jl` options combination behavior: in some cases it wasn't robust and failed providing the expected result. 
-Plus, introduced a new merge format: `-jlnn` - all clashing values will be aggregated (disrespecting JSON structured grouping vs. as in 
+- improved `-jl` options combination behavior: in some cases it wasn't robust and failed providing the expected result.
+Plus, introduced a new merge format: `-jlnn` - all clashing values will be aggregated (disrespecting JSON structured grouping vs. as in
 the case of `-jl`)
 - lifted handling of _atomic JSONs_ - simplified the code allow applying _walk-paths_ now even onto the atomic JSON values
-- extended null-interpolation to _JSON strings_ as well: before it was applied for _JSON arrays_ and _JSON objects_ only). 
+- extended null-interpolation to _JSON strings_ as well: before it was applied for _JSON arrays_ and _JSON objects_ only).
 Now, the empty variable interpolation in the string, following either of `,`, `;` will be taken into account,
 e.g.: `-T'"{}, "'` - if `{}` is empty, then result of interpolation will be empty too: `""`
-- improved buffered file read speed (3 times faster) and _stdin_ buffered speed (1.5-2 times faster), improved handling of 
+- improved buffered file read speed (3 times faster) and _stdin_ buffered speed (1.5-2 times faster), improved handling of
 non-existent/bad file-arguments (when multiple given)
-- enhanced _move_ semantic of `-u`, `-i` operations, so that when used together with `-pp` it also works as expected with those options 
+- enhanced _move_ semantic of `-u`, `-i` operations, so that when used together with `-pp` it also works as expected with those options
 (before it was only working for `-p` and `-pp` notation was ignored)
 - a last in the walk `k` lexeme (e.g.: `-w'... <>k'`) is only subjected for re-interpretation of the label if it's empty (`<>k`) now;
 the non-empty `<..>k` lexeme then doesn't (the value is preserved in the namespace, so no need to re-interpret it then)
-- _template pertain per walk_ feature used to work only for _interleaved_ walks and `-n` was cancelling it (template then were applied 
-round-robin). Now, even with `-n` (i.e., for sequenced walk processing) templates are also pertained per walks, 
+- _template pertain per walk_ feature used to work only for _interleaved_ walks and `-n` was cancelling it (template then were applied
+round-robin). Now, even with `-n` (i.e., for sequenced walk processing) templates are also pertained per walks,
 in the unlikely event when round robin behavior is required `-nn` notation will support it.
 Also, _template pertain per walk_ feature is enhanced to be engaged only when number of _templates_ (`-T`)
 matches the number of provided walks (`-w`), otherwise _round-robin_ template application behavior is engaged.
@@ -97,14 +97,14 @@ usage occurring in processing really huge JSONs only
 with `-J` (and not when `-a` is implicitly imposed upon `-J`)
 - fixed parsing debug (offset for a _streamed_ read now shows a correct value - from the beginning of a stream, instead of
 the beginning of an internal circular buffer, other read debugs (_buffered_, _cin_) are unaffected)
-- fixed empty `<>b` lexeme - it was not working (as documented), now it matches any boolean JSON value (UT'ed) 
+- fixed empty `<>b` lexeme - it was not working (as documented), now it matches any boolean JSON value (UT'ed)
 ***
 
 
 _Release Notes for `jtc` v.1.71_
 
 #### New features:
-- new lexeme: `<..>u` - user evaluation of the current walk-path via shell cli - walking will continue if cli return `0` (success) 
+- new lexeme: `<..>u` - user evaluation of the current walk-path via shell cli - walking will continue if cli return `0` (success)
 and fails otherwise. The cli in the lexeme is subjected for namespaces interpolation
 - full support of `if` ... `else` walk branching via pairing `f` and `F` lexemes:
    - ... `<>f` {if path does not fail, then skip it} `<>F` {otherwise execute this path} ...
@@ -115,26 +115,26 @@ allowing transforming JSONS "on the fly": `... | jtc -a ... | ...`
 - multiple files could be fed to `jtc` now (before it used to accept only one input file)
 
 #### Improvements, changes, fixes:
-- search lexemes and some directives (`naoicewvkfF`) now can write currently walked JSON values into the namespaces, e.g.: `<var>a`, 
-  though `<var:"lbl">k` directive supports only JSON string types (understandably, labels could be represented only as JSON strings); 
+- search lexemes and some directives (`naoicewvkfF`) now can write currently walked JSON values into the namespaces, e.g.: `<var>a`,
+  though `<var:"lbl">k` directive supports only JSON string types (understandably, labels could be represented only as JSON strings);
   thus a walk path previously written as `<>a<var>v` now could be collapsed into `<var>a`
 - extend `<..>j` search lexeme, allowing the lexeme value to be a _templated_ JSON, e.g.: `<{ "{lbl}": {{val}} }>j`; however, it makes
 the search lexeme `j` a _dynamic type_ when used with interpolation template (unlike one with a _static_ JSON), therefore, like
 all dynamic lexemes it is an exempt for caching, hence it's prone to exponential decay noticeable upon big recursive searches - be aware
 when building a query for huge input JSONs
-- for insert/update operations (`-i`, `-u`), destination walks' (`-w`) are related now to the source walk of operations (in 
-`-i`, `-u`) and so are their namespaces; now it becomes possible to make an insert/update based on the cross references from the 
+- for insert/update operations (`-i`, `-u`), destination walks' (`-w`) are related now to the source walk of operations (in
+`-i`, `-u`) and so are their namespaces; now it becomes possible to make an insert/update based on the cross references from the
 destination walks using namespaces
-- swap option `-s` now accept any number of walk _pairs_ to be swapped (before it was only swapping first 2 specified), e.g.: 
+- swap option `-s` now accept any number of walk _pairs_ to be swapped (before it was only swapping first 2 specified), e.g.:
 `jtc -s -w<1_swap_with_next> -w<1_swap_with_prior> -w<2_swap_with_next> -w<2_swap_with_prior> ...`
-- extended option `-l`: once given as `-ll` - if the record does not have a label (i.e. it's a root, or inside an array) **and** the 
+- extended option `-l`: once given as `-ll` - if the record does not have a label (i.e. it's a root, or inside an array) **and** the
 record is the _JSON object_, then it takes the (first) label from the object and its value and uses as a labeled record
 (allows stripping templated values with labels), e.g.: `jtc ... -T'{"label": {{value}} }' -ll` lets interpolated template to be treated
 as the value with the label rather than as a JSON object
 - option `-p` is enhanced to work with cases of mixed args, eg: `jtc ... -u<static> -u<walk> -p` before it wasn't in use, but now
 it will purge all walked _destinations_ - it's done in order to facilitate a cross-referenced purging (so here `-u`/`-i` is just
 a dummy operation only providing ability to cross-reference purge points)
-- fixed auto-generated REGEX namespaces to be properly pertained per walk when cached 
+- fixed auto-generated REGEX namespaces to be properly pertained per walk when cached
 ***
 
 
@@ -170,17 +170,17 @@ not with `-i`, `-u`) is enhanced:
 _Release Notes for `jtc` v.1.68_
 
 #### New features:
-- directive `<..>F` is liberated: now it can be not the last one (explanations in the 
+- directive `<..>F` is liberated: now it can be not the last one (explanations in the
 [User Guide](https://github.com/ldn-softdev/jtc/blob/master/User%20Guide.md#fail-stop-and-forward-directives))
-- extended walking use-cases for `<..>f`: the lexeme also will act upon failed iterable subscripts too (before it used to 
-engage on failing atomic values only), plus walking continues past `<..>F` directive if the latter is present - in such 
+- extended walking use-cases for `<..>f`: the lexeme also will act upon failed iterable subscripts too (before it used to
+engage on failing atomic values only), plus walking continues past `<..>F` directive if the latter is present - in such
 case the failing domain is only covered within `<>f` ... `<>F` lexemes
 - interpolation with stripping (`{}`) now extended to _JSON iterables_ (`[..]` and `{..}`), allows extending _JSON iterables_
 during interpolation (before `{}` was stripping only _JSON strings_ only)
 
 #### Improvements, changes, fixes:
 - improved interleaved walking relevance (removed directives out of considerations when relating walks)
-- improved quotation for shell cli interpolated values (fixed issue when unexpected quoting might occur in literals 
+- improved quotation for shell cli interpolated values (fixed issue when unexpected quoting might occur in literals
 followed quoting character present in the latter)
 - fixed recursive interpolation (when the interpolated JSON value accidentally may undergo interpolation over again)
 - fixed a corner case usage for `<..>f` directive with ranged lexemes when it could have caused an infinite loop
@@ -190,9 +190,9 @@ followed quoting character present in the latter)
 _Release Notes for `jtc` v.1.67_
 
 #### New features:
-- added `<>F` directive - upon walking this one (which is predicated by successful walk of all prior steps) makes walking to proceed 
+- added `<>F` directive - upon walking this one (which is predicated by successful walk of all prior steps) makes walking to proceed
 to the next iteration without producing a match or a fail-stop; the lexeme is supposed to be only the last lexeme in the walk path
-(all further walk lexeme will be discarded) and is meant to be used with (after) `<>f` lexeme. Both lexemes make negative match 
+(all further walk lexeme will be discarded) and is meant to be used with (after) `<>f` lexeme. Both lexemes make negative match
 queries to handle with ease - see [User Guide](https://github.com/ldn-softdev/jtc/blob/master/User%20Guide.md)) for examples
 
 #### Improvements, changes, fixes:
@@ -212,17 +212,17 @@ could just quoted_
 _Release Notes for `jtc` v.1.66_
 
 #### New features:
-- no new features, stability and improvements update 
+- no new features, stability and improvements update
 
 #### Improvements, changes, fixes:
 - fail-stop directive `<..>f` now is fully compatible and operational with any other walk lexemes, all prior limitations are lifted
-(before it was limited by usage with `[-N]`, `[^N]` subscripts) and also now it may take an argument as a namespace (where a 
+(before it was limited by usage with `[-N]`, `[^N]` subscripts) and also now it may take an argument as a namespace (where a
 fail-stop'ed JSON will go upon engaging the lexeme)
 - Extended directives `<..>v` and `<..>f` - if it's given in the format like `<name:json_value>v`, then `json_value` is put
 into the namespace `name` ignoring currently walked JSON element - that allows setting up in the namespace custom JSON values;
 `json_value` value must be a valid JSON though
 - template behavior is finalized:
-   * when template fails (i.e. its interpolation does not result in a valid JSON), then it's not engaged (source JSON is used instead), 
+   * when template fails (i.e. its interpolation does not result in a valid JSON), then it's not engaged (source JSON is used instead),
    except when the interpolation occurs for the shell evaluation - there template is used as it was given: in shell evaluation
    a template parameter it's indistinguishable from the cli, thus user must ensure a valid template interpolation
    * fixed/improved templates interpolation in shell evaluation (before only the last memorized item was interpolating)
@@ -231,10 +231,10 @@ into the namespace `name` ignoring currently walked JSON element - that allows s
    * fixed namespaces in shell interpolation with trailing options (e.g.: `jtc -eu ... \; -u...`) - now the namespace is tracked
    from the trailing option (before the namespace was tracked from the `-w` option, which in that syntax acts as the destination,
    which was illogical)
-   * when performing a shell interpolation (whether a simple or an extended version - with trailed options) templating occurs during 
+   * when performing a shell interpolation (whether a simple or an extended version - with trailed options) templating occurs during
    expansion of shell cli itself, thus option -T has no effect here and entirely ignored
 
-_all the behaviors and use-cases (and those coverd in the 
+_all the behaviors and use-cases (and those coverd in the
 [User Guide](https://github.com/ldn-softdev/jtc/blob/master/User%20Guide.md)) are completely UT'ed_
 
 ***
@@ -243,15 +243,15 @@ _all the behaviors and use-cases (and those coverd in the
 _Release Notes for `jtc` v.1.65_
 
 #### New features:
-- added `<>f` (fail-stop) directive: the directive "remembers" the currently walked JSON node (path) and shall the further walking 
-fail, instead of proceeding to the next iteration, will stop and "recall" the node/path 
+- added `<>f` (fail-stop) directive: the directive "remembers" the currently walked JSON node (path) and shall the further walking
+fail, instead of proceeding to the next iteration, will stop and "recall" the node/path
 
 #### Improvements, changes, fixes:
-- relative offsets with range quantifiers (`>..<t:` and `>..<l:`) now interprets default "head value" not as '0' but rather as 
+- relative offsets with range quantifiers (`>..<t:` and `>..<l:`) now interprets default "head value" not as '0' but rather as
 'the beginning of the _JSON iterable_' - that extends use-cases base (i.e before, to address prior range entries user must know the
 number of prior entries to be able to address, which is rarely the case)
-- for search type `>..<t`, when a value in the NS represents a _JSON number_, index operation now applied onto both types 
-of _JSON iterables_ - arrays and objects (before it was applied to arrays only, and for objects, label match was performed, 
+- for search type `>..<t`, when a value in the NS represents a _JSON number_, index operation now applied onto both types
+of _JSON iterables_ - arrays and objects (before it was applied to arrays only, and for objects, label match was performed,
 which, for _JSON objects_ used to duplicate `>..<l` functionality)
 - improved walk-step iteration logic (eliminated redundant walk-step in some cases - a cosmetic issue from functionality point of view)
 ***
@@ -275,7 +275,7 @@ _Release Notes for `jtc` v.1.63_
 represent it as a _JSON array_, while `$path` stores it as a _JSON string_ value
 - added quantifier interpolation from the namespaces, i.e. a search in notation like `<..>{..}`, where a search
 quantifier `{..}` resolved from the namespace (all types of quantifiers supported with all search suffixes, e.g.: `>blah<R:{lbl}`)
-- quantifier semantic in search types `>..<l` and `>..<t` now let addressing values by relative offsets, i.e., selecting 
+- quantifier semantic in search types `>..<l` and `>..<t` now let addressing values by relative offsets, i.e., selecting
 a neighbor of matched entry (either successive or preceding), so it becomes possible to select "neighbors" of the found entries
 
 #### Improvements, changes, fixes:
@@ -335,7 +335,7 @@ walk-paths
   - `<..>k`: save current JSON element's **k**ey (label/index); it also reinterprets label/index as the value
   - `<..>v`: save into a namespace current element's JSON **v**alue
   - `<..>z`: **z**ip (erase) given name from the namespace (`<>z` will clear entire namespace)
-  - `<..>s`: **s**earch (off the current node) for the JSON matching one in the namespace  
+  - `<..>s`: **s**earch (off the current node) for the JSON matching one in the namespace
   - `<..>t`: search (off the current node) for the **t**ag (label) matching one in the namespace
 #### Improvements, changes, fixes:
 - improved parser debug alignments and aligned indentation for relevant calls/data structures
@@ -346,4 +346,3 @@ walk-paths
 - substitution operation now replaced with interpolation: removed parsing of `{-}`,`[]`,`[-]`; interpolation now occurs
 with `{}` and `{{}}`, the latter one interpolates JSON as it is, the former one affects string interpolation only - the string value
 is interpolated without outer quote marks
-

--- a/User Guide.md
+++ b/User Guide.md
@@ -1,4 +1,3 @@
-
 # [`jtc`](https://github.com/ldn-softdev/jtc). Examples and Use-cases (_v.1.74_)
 
 1. [Displaying JSON](https://github.com/ldn-softdev/jtc/blob/master/User%20Guide.md#displaying-json)
@@ -8,7 +7,7 @@
    * [Validating JSON (`-d`)](https://github.com/ldn-softdev/jtc/blob/master/User%20Guide.md#validating-json)
    * [Forcing strict solidus parsing (`-q`)](https://github.com/ldn-softdev/jtc/blob/master/User%20Guide.md#forcing-strict-solidus-parsing)
    * [Unquoting JSON strings (`-qq`)](https://github.com/ldn-softdev/jtc/blob/master/User%20Guide.md#unquoting-JSON-strings)
-   * [Stringifying JSON (`-rr`)](https://github.com/ldn-softdev/jtc/blob/master/User%20Guide.md#stringifying-json) 
+   * [Stringifying JSON (`-rr`)](https://github.com/ldn-softdev/jtc/blob/master/User%20Guide.md#stringifying-json)
 2. [Walking JSON (`-w`)](https://github.com/ldn-softdev/jtc/blob/master/User%20Guide.md#walking-json)
    * [Walking with subscripts (`[..]`)](https://github.com/ldn-softdev/jtc/blob/master/User%20Guide.md#walking-with-subscripts-offset-lexemes)
      * [Selecting multiple subscripted JSON elements (`[+n], [n:n]`)](https://github.com/ldn-softdev/jtc/blob/master/User%20Guide.md#selecting-multiple-subscripted-json-elements)
@@ -206,7 +205,7 @@ if size only required, then use `-zz` option:
 ```
 bash $ <ab.json jtc -zz
 56
-bash $ 
+bash $
 ```
 
 ### Validating JSON
@@ -225,10 +224,10 @@ bash $ <ab.json jtc -d
 .parsejson(), exception locus: ... Ave",|          "state": "CO,|          "postal code": 80206...
 .location_(), exception spot: --------------------------------->| (offset: 1150)
 jtc json exception: unexpected_end_of_line
-bash $ 
+bash $
 ```
-the vertical pipe symbol `|` in the debug showing JSON replaces new lines, thus it becomes easy to spot the problem. 
-The offset (`1150`) is given in _unicode UTF-8_ characters from the beginning of the input/file/stream. In that particular failure 
+the vertical pipe symbol `|` in the debug showing JSON replaces new lines, thus it becomes easy to spot the problem.
+The offset (`1150`) is given in _unicode UTF-8_ characters from the beginning of the input/file/stream. In that particular failure
 instance, `jtc` found the end of a line, while _JSON string_ `"Co,` is still open (JSON standard does not permit multi-line strings).
 To fix that, the missing quotation mark to be added
 
@@ -251,7 +250,7 @@ bash $ <<<'{ "escaped": "\/", "unescaped": "/" }' jtc -q -d
 .read_json(), exception locus: { "escaped": "\/", "unescaped": "/" }|
 .location_(), exception spot: --------------------------------->| (offset: 33)
 jtc json exception: unquoted_character
-bash $ 
+bash $
 ```
 
 ### Unquoting JSON strings
@@ -260,10 +259,10 @@ If a JSON itself (or a result of JSON walking) is a single JSON string, then som
 ```
 bash $ <<<'"{ \"JSON\": \"example of an embedded JSON\" }"' jtc
 "{ \"JSON\": \"example of an embedded JSON\" }"
-bash $ 
+bash $
 bash $ <<<'"{ \"JSON\": \"example of an embedded JSON\" }"' jtc -qq
 { "JSON": "example of an embedded JSON" }
-bash $ 
+bash $
 bash $ <<<$(<<<'"{ \"JSON\": \"example of an embedded JSON\" }"' jtc -qq) jtc
 {
    "JSON": "example of an embedded JSON"
@@ -282,11 +281,11 @@ When unquoting an empty _JSON string_ (`""`) the resulted blank lines are not ev
 bash $ <<<'[null, "", true]' jtc -w[:] -qq
 null
 true
-bash $ 
+bash $
 ```
 
 NOTE: _the option notation `-qq` will not engulf a single notation `-q`, if both behaviors are required then both variants have
-to be specified (e.g. `jtc -q -qq`, or `jtc -qqq`)_  
+to be specified (e.g. `jtc -q -qq`, or `jtc -qqq`)_
 
 Also, `-qq` is incompatible with `-j`, `-J` options, because of a risk of ill-formed JSON, thus, when sighted together
 option `-qq` is silently ignored
@@ -328,7 +327,7 @@ bash $ <ab.json jtc -w'[Directory][1][address]'
 }
 bash $
 ```
-or, equally could be done like in below example, but the former syntax is preferable (for your own good - when giving indices you'd need 
+or, equally could be done like in below example, but the former syntax is preferable (for your own good - when giving indices you'd need
 to _guess_ the index of a labeled entry, which might be prone to mistakes):
 ```
 bash $ <ab.json jtc -w'[0][1][0]'
@@ -362,7 +361,7 @@ Here, all records (`[+0]`) from the `Directory` have been selected and then in e
 the 2nd entry (`[+1]`)
 
 The same way object elements could be subscripted, here's an example where all address entries starting from the 2nd one are printed,
-each one stating from the 3rd entry: 
+each one stating from the 3rd entry:
 ```
 bash $ <ab.json jtc -w'[Directory][+1][address][+2]'
 "WA"
@@ -373,19 +372,19 @@ bash $
 ```
 
 ##### Subscript slice notation
-Another way to select multiple subscripts is to use a slice notation `[N:N]`. In that notation `N` could be either positive or negative, 
+Another way to select multiple subscripts is to use a slice notation `[N:N]`. In that notation `N` could be either positive or negative,
 or entirely missed. First position designates beginning of the selection, the last position designates the end of the slice exclusively
 (i.e., not including the indexed element itself)
 - positive `N` subscripts `N`th element from the beginning of the collection (whether it's array or an object)
 - negative `N` subscripts the `N`th element from the end of the collection.
 - empty (missed `N`) tells to address either from the the beginning of the collection (in the first position), or from the end
-(last position) 
+(last position)
 
 Thus, multiple notations with the same semantics are possible, e.g.:
 - `[:]`, `[0:]` will select all the element in the collection and is equivalent of `[+0]` notation
 - `[0:1]`, `[:1]` will select only the first element and is the same as `[0]`
 - `[:-1]` will select all the elements except the last one
-- `[-2:]` will select last 2 elements in the collection 
+- `[-2:]` will select last 2 elements in the collection
 
 E.g., let's print all phone numbers for the last 2 records in the `Directory`:
 ```
@@ -398,18 +397,18 @@ bash $
 ```
 
 ### Searching JSON
-Walk-path lexemes enclosed into `<`,`>` braces instruct to perform a _recursive_ search of the value under a selected JSON node. 
+Walk-path lexemes enclosed into `<`,`>` braces instruct to perform a _recursive_ search of the value under a selected JSON node.
 I.e., if a search lexeme appears as the first one in the walk-path, then the search will be done from the root, otherwise
 from the node in JSON where a prior lexeme has stopped.
 
-By default (if no one-letter suffix is given), a search lexeme will perform a search of _JSON string_ values only (i.e., it won't match 
+By default (if no one-letter suffix is given), a search lexeme will perform a search of _JSON string_ values only (i.e., it won't match
 _JSON numerical_ or _JSON boolean_ or _JSON null_ values). E.g., following search finds a match:
 ```
 bash $ <ab.json jtc -w'<New York>'
 "New York"
 bash $
 ```
-while this one doesn't (the string value `New York` is found only in the first `Directory` record): 
+while this one doesn't (the string value `New York` is found only in the first `Directory` record):
 ```
 bash $ <ab.json jtc -w'[Directory][1:]<New York>'
 bash $
@@ -431,10 +430,10 @@ Regex lexemes allow specifying options for the RE search as trailing special sym
 - `\O`: instructs the RE engine to make matching faster at the cost of making construction (parsing) slower (_optimize_)
 - `\C`: character ranges of the form `[a-b]` are locale sensitive (_collate_)
 
-_Note_: a _multiline_ RE option is unsupported due to JSON not supporting multiline strings. Also, 
+_Note_: a _multiline_ RE option is unsupported due to JSON not supporting multiline strings. Also,
 when option `\N` is given, obviously, the
 [auto-generated namespaces for RE subgroups](https://github.com/ldn-softdev/jtc/blob/master/User%20Guide.md#re-generated-namespaces)
-won't be not available 
+won't be not available
 
 
 Also, all following RE grammars are supported:
@@ -451,13 +450,13 @@ E.g., the above example with options `\I` and `\P` (ignore case and use _egrep_ 
 ```
 bash $ <ab.json jtc -w'<^n\I\P>R'
 "New York"
-bash $ 
+bash $
 ```
 
 
 
 #### Search suffixes
-This is the list of suffixes to control search behavior: 
+This is the list of suffixes to control search behavior:
   * `r`: default (could be omitted), fully matches _JSON string_ value
   * `R`: the lexeme is a search RE, only _JSON string_ values searched
   * `P`: matches _any_ string value (like `<.*>R`), the lexeme value might be empty
@@ -476,21 +475,21 @@ This is the list of suffixes to control search behavior:
   * `w`: matches any JSON value (wide range match): atomic values, objects, arrays; the lexeme value may be empty
   * `j`: matches specified JSON value; the lexeme must be either a valid JSON (e.g.: `<[]>j` - finds an empty JSON array), or a
   [template](https://github.com/ldn-softdev/jtc/blob/master/User%20Guide.md#templates)
-  resulting in a valid JSON after 
+  resulting in a valid JSON after
   [interpolation](https://github.com/ldn-softdev/jtc/blob/master/User%20Guide.md#interpolation)
   (e.g.: `<"{str}">j` - finds a _JSON string_ whose value is in
   [namespace](https://github.com/ldn-softdev/jtc/blob/master/User%20Guide.md#directives-and-namespaces)
   `str`)
   * `s`: matches a JSON value previously stored in the namespace by directives: `<..>k`, `<..>v`
-  * `t`: matches a tag (label/index) previously stored in the namespace by directives `<..>k`, `<..>v`  
-  * `q`: matches only original JSON values; lexeme maybe empty, otherwise it provides a namespace, where matched elements will be stored 
+  * `t`: matches a tag (label/index) previously stored in the namespace by directives `<..>k`, `<..>v`
+  * `q`: matches only original JSON values; lexeme maybe empty, otherwise it provides a namespace, where matched elements will be stored
   * `Q`: matches only repetitive (duplicate) JSON values; lexeme may be empty, otherwise it provides a namespace, where matched
   elements will be stored
 
 
 Some search lexemes (and
 [directives](https://github.com/ldn-softdev/jtc/blob/master/User%20Guide.md#directives-and-namespaces))
-require their **content to be set and be non-empty* (`R`,`d`,`D`,`L`,`j`,`s`,`t`,`q`,`Q`,`v`,`u`), otherwise an exception 
+require their **content to be set and be non-empty* (`R`,`d`,`D`,`L`,`j`,`s`,`t`,`q`,`Q`,`v`,`u`), otherwise an exception
 `walk_empty_lexeme` will be thrown
 
 Some lexemes might be left empty, but they cary a semantic of an **empty search** (`r`,`l`,`b`), e.g.: `<>` (same as `<>r`) - will match
@@ -503,21 +502,21 @@ e.g.: `<array>i` - upon a match will preserve found _JSON array_ in the namespac
 ##### Cached Search
 `jtc` is super efficient searching recursively even huge JSONs structures - normally no exponential search decay will be observed
 (which is very typical for such kind of operations). The decay is avoided because `jtc` builds a cache for all searches (whenever
-cacheing is required, both recursive and non-recursive) and thus all subsequent matches are taken from the cache.  
+cacheing is required, both recursive and non-recursive) and thus all subsequent matches are taken from the cache.
 Though, there are cases when search could not be _cached_ in principle - when the search lexeme is a _dynamic_ type, i.e., when
-resolution of the search is dependent on the _namespace_ value.  
+resolution of the search is dependent on the _namespace_ value.
 Here's the list of such search types:
   * `q`,`Q`: the lexemes refer (internally) to _namespaces_ when performing search and hence not cacheable
   * recursive `<..>s`,`<..>t`: those lexemes using _namespaces_ when performing search and hence are not cacheable
   * [non-recursive](https://github.com/ldn-softdev/jtc/blob/master/User%20Guide.md#non-recursive-search)
-  search lexemes with 
-  [relative quantifiers](https://github.com/ldn-softdev/jtc/blob/master/User%20Guide.md#search-quantifiers-with-relative-offset-semantic) 
-  \- `>..<lN`, `>..<tN`: these lexemes simply do not require cacheing - they are not exposed to exponential decay; 
-  note, lexemes `<>lN`, `<>tN` are using regular quantifiers semantic (i.e., match instance) and therefore a subjected for cacheing 
+  search lexemes with
+  [relative quantifiers](https://github.com/ldn-softdev/jtc/blob/master/User%20Guide.md#search-quantifiers-with-relative-offset-semantic)
+  \- `>..<lN`, `>..<tN`: these lexemes simply do not require cacheing - they are not exposed to exponential decay;
+  note, lexemes `<>lN`, `<>tN` are using regular quantifiers semantic (i.e., match instance) and therefore a subjected for cacheing
   * JSON match when lexeme is a template, e.g.: `<{"label": {{val}} }>j`: template typically requires _namespace_ for interpolation
   and hence also non-cacheable (though `j` searches with static JSONs will be cached - e.g.: `<{"label": "val" }>j`)
 
-\- all the above cases are exempt from cacheing and hence the exponential decay might become noticeable, so be aware when building a 
+\- all the above cases are exempt from cacheing and hence the exponential decay might become noticeable, so be aware when building a
 query for very large JSON structures
 
 
@@ -528,7 +527,7 @@ for the currently walked JSON elements:
 
   * `v`: saves the currently walked JSON value into a namespace under the name specified by the lexeme (lexeme cannot be empty)
   * `k`: instructs to reinterpret the key (label/index) of the currently walked JSON and treat it as a value (thus a label/index
-         can be updated/extracted programmatically), if the lexeme's value is non-empty then it saves a found key 
+         can be updated/extracted programmatically), if the lexeme's value is non-empty then it saves a found key
          (label/index) into the corresponding namespace and **cancels reinterpretation** of the label as a value
   * `z`: erases namespace pointed by lexeme value; the lexeme must not be empty
   * `f`: fail-safe: if lexeme walking **past the fail-safe** fails, instead of progressing to the next iteration
@@ -538,26 +537,26 @@ for the currently walked JSON elements:
   * `F`: Forward-Stop: behavior of the directive is dependent on spelling:
     * `<>F` - when the directive is reached, the currently walked path is skipped and silently proceeds to the next walk iteration
     without ending the walk;
-    * `><F` - when the directive is reached, the walk successfully stops for the output processing    
+    * `><F` - when the directive is reached, the walk successfully stops for the output processing
   * `u`: user evaluation of the walk-path: lexeme is the _`shell cli`_ sequence which affects walking: if a returned result of the
   shell evaluation is `0` (success) then walk continues, otherwise the walk fails; the lexeme is subjected for template
   interpolation
   * `I`: increment lexeme - if the namespace value pointed by a lexeme is _JSON number_ then it's incremented by the specified offset
   (e.g. `<var>I-3` will decrement `var` by `3`), if the pointed value is not a _JSON number_ then it's ignored
-   
+
 The use of `F` directive makes only sense paired with `<>f`. Together they cover all cases of walk-paths branching:
   * ... `<>f` {if this path does not fail, then skip it} `<>F` {otherwise walk this path (starting from `<>f` point)} ...
   * ... `<>f` {if this path does not fail, then end current walk} `><F` {otherwise walk this path} ...
   * ... `<>f` {if this path does not fail, then end current walk} `><F <>F` # otherwise skip it (i.e., skip the failed path)
-  * ... `<>f` {if this path does not fail, then end current walk} `><F <>f` {otherwise walk this path, end it if walked successfully} 
+  * ... `<>f` {if this path does not fail, then end current walk} `><F <>f` {otherwise walk this path, end it if walked successfully}
   `><F` {otherwise, if second branching fails, walk this one } ...
   * etc
 
 ##### Namespaces
 
 A _namespace_ is a container(s) within `jtc`, which allows storing JSON elements programmatically while walking JSON.
-Stored in the namespace values could be reused later in the same or different walk-paths and 
-[interpolated](https://github.com/ldn-softdev/jtc/blob/master/User%20Guide.md#interpolation) in 
+Stored in the namespace values could be reused later in the same or different walk-paths and
+[interpolated](https://github.com/ldn-softdev/jtc/blob/master/User%20Guide.md#interpolation) in
 [templates](https://github.com/ldn-softdev/jtc/blob/master/User%20Guide.md#templates) and arguments
 for a shell evaluation.
 
@@ -572,7 +571,7 @@ bash $ <<<'{ "item": "bread", "list":{ "milk": 0.90, "bread": 1.20 } }' jtc
       "milk": 0.90
    }
 }
-bash $ 
+bash $
 ```
 the ask here is to retrieve a value from `list` defined by `item` - that would require a cross-reference lookup.
 Using namespaces it becomes a trivial task:
@@ -580,7 +579,7 @@ Using namespaces it becomes a trivial task:
 bash $ JSN='{ "item": "bread", "list":{ "milk": 0.90, "bread": 1.20 } }'
 bash $ <<<$JSN jtc -w'[item]<itm>v[^0]<itm>t'
 1.20
-bash $ 
+bash $
 ```
 - `[item]<itm>v` - will retrieve a value in `item` and store it in the namespace `itm`
 - `[^0]<itm>t` - will reset the point of departure back to the root, then will search for a label matching the value stored
@@ -595,20 +594,20 @@ bash $ <ab.json jtc -w'<address>l[:]<>k'
 "postal code"
 "state"
 "street address"
-bash $ 
+bash $
 ```
 When the directive lexeme `<>k` is given w/o a value (like shown) then no saving in the namespaces occurs.
 
 The lexeme `<..>v` (and all others which allow _namespaces_ - `naoicewkfF`) allow setting up a custom JSON value (in lieu of
-currently walked JSON) - if the lexeme's value is given in the format:  
-- `<name:JSON_value>v`  
+currently walked JSON) - if the lexeme's value is given in the format:
+- `<name:JSON_value>v`
 then upon walking such syntax a user's `JSON_value` will be preserved in the namespace `name`
 
 
 #### Fail-safe and Forward-Stop directives
 All the lexemes in the _walk-path_ are bound by logical `AND` - only if all succeed then the path is successfully walked (and printed
-or regarded for a respective operation). The _fail-safe_ and _Forward-Stop_ directives make possible to introduce branching logic 
-into the _walk-path_.  
+or regarded for a respective operation). The _fail-safe_ and _Forward-Stop_ directives make possible to introduce branching logic
+into the _walk-path_.
 Let's break it down:
 
 Say, we want to list all `mobile` phone records (let's do it along with names of phone holders):
@@ -619,7 +618,7 @@ bash $ <ab.json jtc -w'[0][:][name]' -w'[0][:][phone]<mobile>[-1]' -r
 "Ivan"
 { "number": "223-283-0372", "type": "mobile" }
 "Jane"
-bash $ 
+bash $
 ```
 As it appears, `Jane` has no mobile phone, but then our requirement is enhanced: for those who do not have a `mobile`, let's list
 the first available phone from the records (there a `<>f` directive comes to a rescue):
@@ -631,7 +630,7 @@ bash $ <ab.json jtc -w'[0][:][name]' -w'[0][:][phone][0] <>f [-1]<mobile>[-1]' -
 { "number": "223-283-0372", "type": "mobile" }
 "Jane"
 { "number": "358-303-0373", "type": "office" }
-bash $ 
+bash $
 ```
 as the path is walked, as soon `<>f` directive is faced, `jtc` _memorizes_ the currently walked path point and will _recall_ it shall
 further walking fails, there:
@@ -640,16 +639,16 @@ further walking fails, there:
      * if it's found, we step back up (`[-1]`) again to finish walking and display the whole record
      * if not found (i.e., walking indeed fails), a fail-safe is engaged and preserved location is recalled and displayed
 
-A _walk-path_ may contain multiple _fail-safe_, only the respective fail-safe will be engaged (more specific one and closest 
+A _walk-path_ may contain multiple _fail-safe_, only the respective fail-safe will be engaged (more specific one and closest
 one to the failing point)
 
 The _fail-safe_ directive, (as well as `<..>v`) may carry a value (namespace), which will be populated with the currently walked
-JSON element (for later interpolation), and, as well as `<..>v`, the _fail-safe_ is also allowed setting up custom JSON values 
+JSON element (for later interpolation), and, as well as `<..>v`, the _fail-safe_ is also allowed setting up custom JSON values
 (when used in the format: `<namespace:JSON_value>f`)
 
 ##### Here's another example sporting _fail-safe_ using namespaces and interpolation:
-Say we want to list from the address book all the record holders and indicate whether they have any children or not in 
-this format 
+Say we want to list from the address book all the record holders and indicate whether they have any children or not in
+this format
 `{ "Name has children": true/false }`
 
 Thus, we need to build a single path, which will find the `name`, then inspect `children` record and transform it into
@@ -658,15 +657,15 @@ Thus, we need to build a single path, which will find the `name`, then inspect `
 We can do it in steps:
 1. let's get to the `name`s first and memorize those:
 ```
-bash $ <ab.json jtc -x'[0][:][name]<person>v' 
+bash $ <ab.json jtc -x'[0][:][name]<person>v'
 "John"
 "Ivan"
 "Jane"
-bash $ 
+bash $
 ```
 2. Now let's inspect a sibling record `children`:
 ```
-bash $ <ab.json jtc -x'[0][:][name]<person>v [-1][children]' 
+bash $ <ab.json jtc -x'[0][:][name]<person>v [-1][children]'
 [
    "Olivia"
 ]
@@ -675,15 +674,15 @@ bash $ <ab.json jtc -x'[0][:][name]<person>v [-1][children]'
    "Robert",
    "Lila"
 ]
-bash $ 
+bash $
 ```
 3. so far so good, but we need to engage _fail-safe_ to facilitate the requirement to classify those records as `true` / `false`:
 ```
-bash $ <ab.json jtc -x'[0][:][name]<person>v [-1][children]<kids:false>f[0]<kids:true>v' 
+bash $ <ab.json jtc -x'[0][:][name]<person>v [-1][children]<kids:false>f[0]<kids:true>v'
 "Olivia"
 []
 "Robert"
-bash $ 
+bash $
 ```
 - there namespace `kids` will be populated first with JSON value `false` and will stay put shall further walking fails;
 - otherwise (i.e., upon a successful walk - addressing a first child `[0]`) the namespace `kids` will be overwritten
@@ -695,7 +694,7 @@ bash $ <ab.json jtc -x'[0][:][name]<person>v [-1][children]<kids:false>f[0]<kids
 { "John has children": true }
 { "Ivan has children": false }
 { "Jane has children": true }
-bash $ 
+bash $
 ```
 
 
@@ -716,7 +715,7 @@ bash $ <<<$JSN jtc
       "name": "printer"
    }
 ]
-bash $ 
+bash $
 ```
 How do we list only those records which don't have `name` and skip those which do? Well, one apparent solution then would be
 to walk all those entries, which do have `name` labels and purge them:
@@ -727,17 +726,17 @@ bash $ <<<$JSN jtc -w'<name>l:[-1]' -p
       "ip": "1.1.1.100"
    }
 ]
-bash $ 
+bash $
 ```
 But what if we want to walk them instead of purging (e.g., for reason of template-interpolating the entries at the output)?
-The prior solution would require piping the output to the next `jtc` cli, however, it's possible to achieve the same using this 
+The prior solution would require piping the output to the next `jtc` cli, however, it's possible to achieve the same using this
 simple query:
 ```
 bash $ <<<$JSN jtc -w'[:]<>f[name]<>F'
 {
    "ip": "1.1.1.100"
 }
-bash $ 
+bash $
 ```
 Without `<>F` directive, the walk would look like:
 ```
@@ -747,13 +746,13 @@ bash $ <<<$JSN jtc -w'[:]<>f[name]'
    "ip": "1.1.1.100"
 }
 "printer"
-bash $ 
+bash $
 ```
-Thus, `<>F` skips those (successfully) matched entries, leaving only one which fails - that's the one which we need in this query 
+Thus, `<>F` skips those (successfully) matched entries, leaving only one which fails - that's the one which we need in this query
 (the record(s) which does not have `name` in it)
 
 
-Now, what if in the latter example above (one with `<>F` directive) we want to process *failed* JSON further, say, to display ip only, 
+Now, what if in the latter example above (one with `<>F` directive) we want to process *failed* JSON further, say, to display ip only,
 w/o object itself? That is easily achievable - walking of the *failed* path continues past the `<>F` directive:
 ```
 bash $ <<<$JSN jtc -w'[:]<>f[name]<>F [ip]'
@@ -761,7 +760,7 @@ bash $ <<<$JSN jtc -w'[:]<>f[name]<>F [ip]'
 bash $
 ```
 So, the walking sequence (for the failed, second entry) would be like this:
-- upon walking `[name]` lexeme, path would fail (the second record does not have one), so the path vector would be reinstated 
+- upon walking `[name]` lexeme, path would fail (the second record does not have one), so the path vector would be reinstated
 to the exact point when it was right at `<>f` directive (which is the second entry itself)
 - then walking continues past the next `<>F` directive, which is `[ip]`
 
@@ -778,9 +777,9 @@ bash $ <ab.json jtc -w'<^J(.*)>R:'
 bash $ <ab.json jtc -w'<^J(.*)>R:' -T'"j{$1}"'
 "john"
 "jane"
-bash $ 
+bash $
 ```
-(coverage of REGEX is entirely out of scope of this document, rather refer to this external link: 
+(coverage of REGEX is entirely out of scope of this document, rather refer to this external link:
 [Regular Expression](https://www.regular-expressions.info/))
 
 
@@ -794,19 +793,19 @@ bash $ <ab.json jtc -w'<Jane>' -T'{{$PATH}}' -r
 [ "Directory", 2, "name" ]
 bash $ <ab.json jtc -w'<NY>' -T'{{$path}}'
 "Directory_0_address_state"
-bash $ 
+bash $
 ```
 to play safe with the templates, always surround them with single quotes (to dodge shell interpolation)
 
 
 #### Search quantifiers
-Optionally a quantifier may follow the search lexeme (if a lexeme has a suffix, then the quantifier must come after the suffix). 
+Optionally a quantifier may follow the search lexeme (if a lexeme has a suffix, then the quantifier must come after the suffix).
 Quantifiers in search lexemes allow selecting match instance (i.e., select first match, second one, etc, or a range of matches)
 Quantifiers exist in the following formats:
 - `n`, - a positive number - tells which instance of a match to pick. By default, a quantifier `0` is applied
 (i.e., first match is selected)
 - `+n` - selects all match instances starting from `n`th (zero based)
-- `N:N` - slice select: the notation rules for this quantifier the same as for 
+- `N:N` - slice select: the notation rules for this quantifier the same as for
 [subscript slices](https://github.com/ldn-softdev/jtc/blob/master/User%20Guide.md#subscript-slice-notation)
 (`[N:N]`), with just one understandable caveat: `N` here cannot go negative (there's no way of knowing upfront how many
 matches would be produced, so it's impossible to select a range/slice based off the last match), the rest of the notation rules apply
@@ -826,16 +825,16 @@ bash $
 _JSON arrays_ here - `i`) starting from second one (all quantifiers and indices are zero-based)
 
 
-#### Search quantifiers with relative offset semantic 
+#### Search quantifiers with relative offset semantic
 There are two search lexemes where matching non-first instance does not make sense, namely: `>..<l` and `>..<t`.
-Those are 
+Those are
 [non-recursive searches](https://github.com/ldn-softdev/jtc/blob/master/User%20Guide.md#non-recursive-search)
 will uniquely match label or index. Indeed, in a plain _JSON array_ or an _object_ it's possible
 to address only one **single** label or index, there could not be any other, e.g. in this JSON:
 ```
 bash $ <<<'{ "a": 1, "b":2, "c":3, "d":4, "e":6 }' jtc -r
 { "a": 1, "b": 2, "c": 3, "d": 4, "e": 6 }
-bash $ 
+bash $
 ```
 there could be only one label `"b"`, thus normally trying to match a second, third, etc instance of the label `"b"` would not
 make much of a sense: `<<<'{ "a": 1, "b":2, "c":3, "d":4, "e":6 }' jtc -w'>b<l2'`
@@ -846,15 +845,15 @@ once match found then its second (successive) neighbor value will be selected:
 ```
 bash $ <<<'{ "a": 1, "b":2, "c":3, "d":4, "e":6 }' jtc -w'>b<l2' -l
 "d": 4
-bash $ 
+bash $
 ```
-Because of change in semantic, those are the only search quantifiers (they also have to be non-recursive spelling: `>..<l`, `>..<t`) 
+Because of change in semantic, those are the only search quantifiers (they also have to be non-recursive spelling: `>..<l`, `>..<t`)
 which allow negative values. Positive quantifiers let selecting next (successive) neighbors, while negative quantifiers let
 selecting preceding neighbors:
 ```
 bash $ <<<'{ "a": 1, "b":2, "c":3, "d":4, "e":6 }' jtc -w'>b<l-1' -l
 "a": 1
-bash $ 
+bash $
 ```
 
 #### Last Walk namespace
@@ -871,11 +870,11 @@ bash $ <<<'["a","b","c"]' jtc -w[:] -T'[{$?}, {{}}]' -r
 [ "a", "b", "c" ]
 ```
 When interpolation of $? occurs first time (i.e. there was no prior walk), or when interpolation of $? fails, then the value of this
-namespace is reset to an empty string (`""`).  
+namespace is reset to an empty string (`""`).
 The use of that variable comes handy when converting JSON to a `csv` format.
 
 
-#### Scoped search 
+#### Scoped search
 Search lexemes perform a _recursive_ search across the entire JSON tree off the point where it's invoked (i.e., the JSON node
 selected by walking all the prior lexemes). However, sometimes there's a need to limit searching scope only to the specific label.
 Here is the dump of all the _JSON strings_, where symbol `5` is sighted:
@@ -982,7 +981,7 @@ bash $
 The walk-path break down:
 1. `<children>l:` - find all records by label `"children"`
 2. `[0]` - try addressing first element in the found records (that'll ensure that `children` is non-empty)
-3. `[-2]` - go 2 parents up for those records which survived the prior step - that'll bring us to the person's record level 
+3. `[-2]` - go 2 parents up for those records which survived the prior step - that'll bring us to the person's record level
 4. `[type]:<mobile>` - find recursively `mobile` string scoped by `type` (already only for those records which have children)
 5. `[-3]`-  go 3 levels (parents) up (for those records which have `children` and have `mobile` types of phone records) - it'll bring
 us again up to the person's record level
@@ -1012,7 +1011,7 @@ to address a parent from root: [^0]      [^1]       [^2]      [^3]       [^4]
                                 |          |          |         |          |
 to address a parent from leaf: [-4]      [-3]       [-2]      [-1]       [-0]
                                [-5]
-                               etc.                         
+                               etc.
 ```
 
 
@@ -1072,7 +1071,7 @@ bash $
 the result will vary:
 - `-j` without `-l` will just arrange walked entries into a JSON array:
   ```
-  bash $ <ab.json jtc -w'<name>l:' -w'<number>l:' -nj 
+  bash $ <ab.json jtc -w'<name>l:' -w'<number>l:' -nj
   [
      "John",
      "Ivan",
@@ -1141,7 +1140,7 @@ bash $ <ab.json jtc -w'<name>l:' -w'<number>l:'
 bash $
 ```
 Those look interleaved, though it does not appear that they relate to each other properly: e.g.: number `"113-123-2368"`
-belong to `"John"` and preferably should be displayed before `"Ivan"` and so does apply to others. `jtc` is capable of 
+belong to `"John"` and preferably should be displayed before `"Ivan"` and so does apply to others. `jtc` is capable of
 processing/printing relevant entries, though it needs a little hint from the walk-paths: the latter supposed to express the
 relevance between themselves.
 
@@ -1211,7 +1210,7 @@ bash $ <ab.json jtc -w '[Directory][:]<name>l:' -w'[Directory][:] <number>l:' -j
       ]
    }
 ]
-bash $ 
+bash $
 ```
 
 
@@ -1221,7 +1220,7 @@ which do not have labels (i.e., elements in _JSON array_ and root) will be ignor
 
 E.g., let's dump all values from `Jane`'s record and wrap them all into an object:
 ```
-bash $ <ab.json jtc -w'<Jane>[-1]<>a:' -jj 
+bash $ <ab.json jtc -w'<Jane>[-1]<>a:' -jj
 {
    "age": 25,
    "city": "Denver",
@@ -1239,7 +1238,7 @@ bash $ <ab.json jtc -w'<Jane>[-1]<>a:' -jj
       "home"
    ]
 }
-bash $ 
+bash $
 ```
 As one can see, even though `Jane` has 2 lovely children (`Robert` and `Lila`), they were not listed on the resulting output,
 because they are enlisted in _JSON array_ and therefore have no attached labels (and hence ignored).
@@ -1269,10 +1268,10 @@ bash $ <ab.json jtc -w'[0][:][name]'
 "John"
 "Ivan"
 "Jane"
-bash $ 
+bash $
 ```
 
-2\. Crafting a new record would require knowing 
+2\. Crafting a new record would require knowing
 [templates](https://github.com/ldn-softdev/jtc/blob/master/User%20Guide.md#templates)
 and
 [namespace interpolation](https://github.com/ldn-softdev/jtc/blob/master/User%20Guide.md#interpolation)
@@ -1285,14 +1284,14 @@ bash $ <ab.json jtc -w'[0][:][name]' -w'[0][:][children] <C:"no">f[0]<C:"yes">v'
 []
 "Jane"
 "Robert"
-bash $ 
+bash $
 ```
 \- the second walk above features a couple concepts:
 - [branching](https://github.com/ldn-softdev/jtc/blob/master/User%20Guide.md#fail-safe-and-forward-stop-directives)
-(`<..>f`) _fail-safe_ lexeme: ensures that the walk is reinstated at the placement of the lexeme if/once the 
+(`<..>f`) _fail-safe_ lexeme: ensures that the walk is reinstated at the placement of the lexeme if/once the
 subsequent walk fails
 - [namespaces](https://github.com/ldn-softdev/jtc/blob/master/User%20Guide.md#namespaces)
-(`<C:"no">f`, `<C:"yes">v`): both lexemes setup the _namespace_ `C`, initially to value `"no"` then to value `"yes"`; 
+(`<C:"no">f`, `<C:"yes">v`): both lexemes setup the _namespace_ `C`, initially to value `"no"` then to value `"yes"`;
 the latter value will override the former only if walking `[0]` was successful (i.e., if the person indeed has at least one child,
 b/c if array `children` were empty, that walk would fail)
 
@@ -1312,16 +1311,16 @@ bash $ <ab.json jtc -w'[0][:][name]' -w'[0][:][children] <C:"no">f[0]<C:"yes">v'
 {
    "has children": "yes"
 }
-bash $ 
+bash $
 ```
 4. okay, we're getting closer, but now we want to display all records with labels:
 ```
 bash $ <ab.json jtc -w'[0][:][name]' -w'[0][:][children] <C:"no">f[0]<C:"yes">v' -TT -T'{"has children": "{C}"}' -l
 "name": "John"
 jtc jnode exception: label_accessed_not_via_iterator
-bash $ 
+bash $
 ```
-Bummer! The exception (rightfully) occurs here because trying to find an outer label of an interpolated JSON 
+Bummer! The exception (rightfully) occurs here because trying to find an outer label of an interpolated JSON
 `{ "has children": "yes" }` fails - indeed it's a standalone JSON, and root does not have any label attached - hence the exception.
 In the situations like this, we'd rather want to reach out inside the object for the labeled value rather than find an outer label.
 The option `-ll` facilitates that need:
@@ -1341,11 +1340,11 @@ bash $ <ab.json jtc -w'[0][:][name]' -w'[0][:][children] <C:"no">f[0]<C:"yes">v'
       "name": "Jane"
    }
 ]
-bash $ 
+bash $
 ```
-Finally - what's `-TT` in there? It's a dummy template (one which surely fails). It needed because if it wasn't here, then 
-a single template would apply to both walks (and we don't want our template to apply onto the first walk). So, we'd need to provide 
-a dummy one so that each 
+Finally - what's `-TT` in there? It's a dummy template (one which surely fails). It needed because if it wasn't here, then
+a single template would apply to both walks (and we don't want our template to apply onto the first walk). So, we'd need to provide
+a dummy one so that each
 [template would relate to own walk](https://github.com/ldn-softdev/jtc/blob/master/User%20Guide.md#multiple-templates-and-interleaved-walks)
 . If templates fails (and `-TT` surely does) then no interpolation applied and walked iteration result is used as it is.
 
@@ -1353,8 +1352,8 @@ a dummy one so that each
 #### Succinct walk-path syntax
 If you look at the prior example
 ([Interleaved walk processing](https://github.com/ldn-softdev/jtc/blob/master/User%20Guide.md#interleaved-walk-processing))
-, you may notice that a common part of both walk-paths (`[Directory][:]`) we had to give twice. There's a way to express it in more 
-succinct syntax: options `-x` and `-y` allows rearrange walk-paths so that `-x` takes an initial common part of the walk-path, 
+, you may notice that a common part of both walk-paths (`[Directory][:]`) we had to give twice. There's a way to express it in more
+succinct syntax: options `-x` and `-y` allows rearrange walk-paths so that `-x` takes an initial common part of the walk-path,
 whereas `-y` would take care of the individuals trailing pars. Thus the same example cold have been written like this:
 ```
 bash $ <ab.json jtc -x'[Directory][:]' -y'<name>l:' -y'<number>l:'
@@ -1370,7 +1369,7 @@ bash $ <ab.json jtc -x'[Directory][:]' -y'<name>l:' -y'<number>l:'
 bash $
 ```
 \- each occurrence of `-x` will be reconciled with all subsequent `-y` (until next `-x` is faced). Options `-x`, `-y` is merely
-a syntactical sugar and do not apply any walk-path parsing or validation, instead they just result in the respective `-w` options 
+a syntactical sugar and do not apply any walk-path parsing or validation, instead they just result in the respective `-w` options
 creations (internally), then the latter get processed. Thus, it's even possible to write it with what it seems a broken syntax at first:
 ```
 bash $ <ab.json jtc -x'[Directory][:' -y']<name>l:' -y']<number>l:'
@@ -1379,7 +1378,7 @@ bash $ <ab.json jtc -x'[Directory][:' -y']<name>l:' -y']<number>l:'
 However, if a reinstatement of the options results in a valid walk-path - that's all what matters.
 
 It's possible to combine both syntaxes (i.e., `-w` with `-x` and `-y`), however, given that the processing of `-x` and `-y`
-internally reinstates respective options `-w`, the former will be appended after any of given `-w` options (which will affect the 
+internally reinstates respective options `-w`, the former will be appended after any of given `-w` options (which will affect the
 order of processing/outputting) even though the order of their appearance is different:
 ```
 bash $ <ab.json jtc -x'[Directory][:]' -y'<name>l:' -y'<number>l:' -w '<children>l:' -rnl
@@ -1397,7 +1396,7 @@ bash $ <ab.json jtc -x'[Directory][:]' -y'<name>l:' -y'<number>l:' -w '<children
 "number": "333-638-0238"
 bash $
 ```
-- here `children` walked first, because `name` and `number` walks undergo reconciliation (internally) and inserted *after* all options 
+- here `children` walked first, because `name` and `number` walks undergo reconciliation (internally) and inserted *after* all options
 
 #### Controlling displayed walks
 By default all walks (`-w`) will be displayed (unless `jtc` carries any of modification operations like insert/update/swap/purge, then
@@ -1405,13 +1404,13 @@ the entire JSON will be displayed). However, there's a way to control which ones
 such capability.
 
 If argument of option `-x` is given in any of notations `-xn`, `-xn/N`, `-x/N` - where `n` and `N` are numbers, then it controls
-a frequency of the displayed walks (and does not represent a common portion of a walk-path).  
+a frequency of the displayed walks (and does not represent a common portion of a walk-path).
 The first number `n` in that notation tells to display every `n`th walk. if `n` is `0` it tells to display `N`th walk once (and in such
 case `0` - a default value - can be omitted resulting in the syntax `-x/N`)
 The second (optional) number `N` tells to begin displaying walks starting from `N`th one (`N` is an index and thus is zero based, default
 value is `0`).
 
-Both `n` and `N` are generally positive numbers, though there's a special notation `-x/-1` - in such case _the last walk_ is ensured 
+Both `n` and `N` are generally positive numbers, though there's a special notation `-x/-1` - in such case _the last walk_ is ensured
 to be displayed
 
 Say, we want to display _every 4th walk_ of the below JSON:
@@ -1426,7 +1425,7 @@ bash $ <<<'[1,2,3,4,5,6,7,8,9]' jtc -w[:]
 7
 8
 9
-bash $ 
+bash $
 ```
 One way to achieve that would be to use templates (the trick is shown in
 [Multiple templates and walks](https://github.com/ldn-softdev/jtc/blob/master/User%20Guide.md#multiple-templates-and-walks)
@@ -1435,16 +1434,16 @@ section), but it's quite impractical. Much easier is to use `-x` option here:
 bash $ <<<'[1,2,3,4,5,6,7,8,9]' jtc -w[:] -x4
 4
 8
-bash $ 
+bash $
  ```
 To display _every 4th walk starting from 3rd one_, use this notation:
 ```
 bash $ <<<'[1,2,3,4,5,6,7,8,9]' jtc -w[:] -x4/2
 3
 7
-bash $ 
+bash $
 ```
-\- reminder: the second number in the option is an index and thus is zero based.  
+\- reminder: the second number in the option is an index and thus is zero based.
 Lets add to the output the very first walk and the last one:
 ```
 bash $ <<<'[1,2,3,4,5,6,7,8,9]' jtc -w[:] -x4/2 -x/0 -x/-1
@@ -1452,7 +1451,7 @@ bash $ <<<'[1,2,3,4,5,6,7,8,9]' jtc -w[:] -x4/2 -x/0 -x/-1
 3
 7
 9
-bash $ 
+bash $
 ```
 
 
@@ -1474,23 +1473,23 @@ different flavors, one of them is the `walk-path` per-se.
 (e.g., daisy-chained through the pipe `|`)
 
 
-### In-place JSON modification 
+### In-place JSON modification
 By default `jtc` will expect input from `stdin`. If the standalone argument `json_file` is given, then `jtc` will read
 input from the file (ignoring `stdin`), see below:
 ```
-bash $ cat file.json 
+bash $ cat file.json
 [
    "JSON",
    "in",
    "file"
 ]
-bash $ 
+bash $
 bash $ <<<'[ "<stdin>", "JSON" ]' jtc
 [
    "<stdin>",
    "JSON"
 ]
-bash $ 
+bash $
 bash $ <<<'[ "<stdin>", "JSON" ]' jtc file.json
 [
    "JSON",
@@ -1503,13 +1502,13 @@ If option `-f` is given (together with a _single_ `json_file` argument) then `jt
 into the file (instead of `stdout`):
 ```
 bash $ <<<'[ "<stdin>", "JSON" ]' jtc -f file.json
-bash $ cat file.json 
+bash $ cat file.json
 [
    "JSON",
    "in",
    "file"
 ]
-bash $ 
+bash $
 ```
 In the above example, JSON is read from `file.json` and output back into the file (`stdin` input is ignored).
 
@@ -1521,7 +1520,7 @@ bash $ cat file.json
    "input",
    "JSON"
 ]
-bash $ 
+bash $
 ```
 
 
@@ -1603,7 +1602,7 @@ bash $
 _\- for the sake of example brevity, swapped elements only sorted out_
 
 
-Possibly, a more frequent use-case for `-s` is when it's required to remove some extra/redundant nestedness in a JSON structure. 
+Possibly, a more frequent use-case for `-s` is when it's required to remove some extra/redundant nestedness in a JSON structure.
 For the sake of example, let's remove _array_ encapsulation from phone records, leaving only the last phone in it:
 ```
 bash $ <<<$(<ab.json jtc -w'<phone>l:' -w'<phone>l:[-1:]' -s) jtc -w'<phone>l:' -l
@@ -1630,7 +1629,7 @@ Finally, using `-s` more than one pair of walks (-w) could be swapped out. In fa
 ### Insert operations
 when either of insert (`-i`) of update (`-u`) operation is carried, there could exist 2 types of walks:
  - one facilitating insert/update points, a.k.a destination walks
- - one facilitating points (elements) being inserted/updated, a.k.a. source walks 
+ - one facilitating points (elements) being inserted/updated, a.k.a. source walks
 
 for insert (`-i`) operations, the destination points of insertion are given using `-w` option(s) while the argument under `-i`
 itself is the source of the insertion (multiple `-i` options could be given). The source of insertion must _always_ be
@@ -1641,11 +1640,11 @@ There are 3 different flavors of insertion arguments:
 - `-i <file>` - JSON being inserted is read from the file
 - `-i <JSON>` - the argument itself a JSON string
 - `-i <walk-path>` - the argument is a walk-path in the input JSON
-all 3 flavors of of insert arguments could be mixed and used together (with some limitation, covered in 
+all 3 flavors of of insert arguments could be mixed and used together (with some limitation, covered in
 [use of mixed arguments](https://github.com/ldn-softdev/jtc/blob/master/User%20Guide.md#use-of-mixed-arguments-for--i--u--c) section)
-)  
+)
 If option arguments types are **not** mixed, then for the first two cases (`<file>` and `<JSON>`) source of the operation are external
-to the input JSON. In the latter case (`<walk-path>`), both destination (`-w`) and source walk the same input JSON.  
+to the input JSON. In the latter case (`<walk-path>`), both destination (`-w`) and source walk the same input JSON.
 
 
 
@@ -1656,16 +1655,16 @@ How does `jtc` know which argument is supplied? The disambiguation path is like 
 
 _Attention is required when passing a `<walk-path>` type argument: some walk-paths look exactly like JSON, e.g:
 `[0]` - this is both a valid JSON array (made of a single numeric value `0`) and a valid walk-path (addressing the first element
-in an iterable), hence such argument will be treated as JSON.  
+in an iterable), hence such argument will be treated as JSON.
 To pass it as a walk-path, modify it to a range-type of walk, e.g.: `[0:1]` - that is still a valid walk-path (selecting only the
-first element) but is invalid JSON.  
-Alternatively, add a trailing space at the end of the walk-lexeme: `[0] ` - then the argument will be treated as a walk-path (in 
+first element) but is invalid JSON.
+Alternatively, add a trailing space at the end of the walk-lexeme: `[0] ` - then the argument will be treated as a walk-path (in
 `-i`, `-u` arguments the `<JSON>` argument is expected to have no trailing white spaces)_
 
 
 #### Destination driven insertion
 The destination insertion point(s) (`-w`) controls how insertion is done:
-- if a given destination insertion point (`-w`) is a single walk and non-iterable - i.e., if it's a single point location - then 
+- if a given destination insertion point (`-w`) is a single walk and non-iterable - i.e., if it's a single point location - then
 all the supplied sources are attempted to get inserted into a single destination location:
 ```
 bash $ <ab.json jtc -w'<children>l:' -lr
@@ -1720,7 +1719,7 @@ bash $
 
 #### Insertion matrix without merging
 Source (JSON being inserted) and destination (JSON point where insertion occurs) elements might represent different types:
-_JSON array_, _JSON object_, _JSON atomic_. Thus there's a number of variants of insertions of one type of elements into others. 
+_JSON array_, _JSON object_, _JSON atomic_. Thus there's a number of variants of insertions of one type of elements into others.
 All such variants are shown in the below matrix table:
 ```
   to \ from  |        [3,4]        |     {"a":3,"c":4}     |      "a":3,"c":4      |      3
@@ -1752,7 +1751,7 @@ option `-m` (merge) alters the behavior of insert operation into following:
 ```
 - merging option allows insertion into the atomic values, but it gets converted into an _JSON array_ first
 - arrays are merged now
-- clashing labels (for merged objects/object members) are also converted into arrays (if not yet) and merged 
+- clashing labels (for merged objects/object members) are also converted into arrays (if not yet) and merged
 
 
 ### Update operations
@@ -1764,7 +1763,7 @@ share the same qualities:
 - both support _move_ (`-p`) semantic (
 [covered later](https://github.com/ldn-softdev/jtc/blob/master/User%20Guide.md#insert-update-with-move)
 )
-- both support _shell evaluation_ (`-e`) of argument 
+- both support _shell evaluation_ (`-e`) of argument
 ([covered later](https://github.com/ldn-softdev/jtc/blob/master/User%20Guide.md#insert-update-argument-shell-evaluaton)
 )
 
@@ -1805,7 +1804,7 @@ bash $ <<<$(<ab.json jtc -w'<address>l:[:]<>k' -eu '<<<{{}}' tr '[:lower:]' '[:u
 "address": { "CITY": "New York", "POSTAL CODE": 10012, "STATE": "NY", "STREET ADDRESS": "599 Lafayette St" }
 "address": { "CITY": "Seattle", "POSTAL CODE": 98104, "STATE": "WA", "STREET ADDRESS": "5423 Madison St" }
 "address": { "CITY": "Denver", "POSTAL CODE": 80206, "STATE": "CO", "STREET ADDRESS": "6213 E Colfax Ave" }
-bash $ 
+bash $
 ```
 
 NOTE: _mind the caveat - destination walk-path may become invalid (namely, when altering labels of the nested elements after
@@ -1817,7 +1816,7 @@ bash $ <ab.json jtc -x[Directory][0][address] -y'<>k' -y'[:]<>k'
 "postal code"
 "state"
 "street address"
-bash $ 
+bash $
 bash $ <<<$(<ab.json jtc -x[Directory][0][address] -y'<>k' -y'[:]<>k' -eu '<<<{{}}' tr '[:lower:]' '[:upper:]' \;) jtc -w'[Directory][0]'
 error: destination walk became invalid, skipping update
 error: destination walk became invalid, skipping update
@@ -1847,7 +1846,7 @@ error: destination walk became invalid, skipping update
    ],
    "spouse": "Martha"
 }
-bash $ 
+bash $
 ```
 
 to achieve what's intended, first the most inner labels have to be walked/processed and then the outers:
@@ -1877,10 +1876,10 @@ bash $ <<<$(<ab.json jtc -x[Directory][0][address] -y'[:]<>k' -y'<>k' -eu '<<<{{
    ],
    "spouse": "Martha"
 }
-bash $ 
+bash $
 ```
 
-**The above caveat is applicable only when label is being updated using _cli evaluation_.**  
+**The above caveat is applicable only when label is being updated using _cli evaluation_.**
 When labels updated without _cli evaluation_ then recursive update is not a problem:
 ```
 bash $ <<<$(<ab.json jtc -x[Directory][0][address] -y'<L>k<>k' -y'[:]<L>k<>k' -u0 -T'"NEW-{L}"') jtc -w'[Directory][0]'
@@ -1908,14 +1907,14 @@ bash $ <<<$(<ab.json jtc -x[Directory][0][address] -y'<L>k<>k' -y'[:]<L>k<>k' -u
    ],
    "spouse": "Martha"
 }
-bash $ 
+bash $
 ```
 \- double lexeme notation `<L>k<>k` is required because `<L>k` will only memorize the label in the namespace `L` but will not trigger
 label re-interpretation like a value, while second lexeme (`<>k`) - does.
 
 
 
-### Insert, Update with move semantic 
+### Insert, Update with move semantic
 if a source argument for either `-i` or `-u` is given in the form of `<file>` or `<JSON>`, then those obviously cannot be moved.
 The move semantic is only applicable when the argument is given only in the form of a `<walk-path>`, then upon completing
 the operation, the source elements (referred by the source walk-path) become possible to remove (purge).
@@ -1999,10 +1998,10 @@ bash $
 
 
 ### Insert, Update: argument shell evaluation
-An argument for _insert_ and _update_ operations (`-i`, `-u`) optionally may undergo a shell evaluation (predicated by preceding `-e`). 
+An argument for _insert_ and _update_ operations (`-i`, `-u`) optionally may undergo a shell evaluation (predicated by preceding `-e`).
 E.g., let's capitalize all the `name` entries in the address book:
 ```
-bash $ <ab.json jtc -w'<name>l:' 
+bash $ <ab.json jtc -w'<name>l:'
 "John"
 "Ivan"
 "Jane"
@@ -2025,7 +2024,7 @@ promoted to a _JSON string_ value)
 (then JSON entry wont be updated/inserted, rather proceed to the next walked entry for another/next update attempt)
 - templates (`-T`) are ignored (unused) - template-interpolation already occurs during the _cli evaluation_
 
-if shell cli does not deliver expected result for some reason, it's easy to see why with `-dd` option, e.g, say, we want to 
+if shell cli does not deliver expected result for some reason, it's easy to see why with `-dd` option, e.g, say, we want to
 truncate all kid's names to 3 letters only (just for fun):
 ```
 bash $ <<<$(<ab.json jtc -w'<children>l:[:]' -j) jtc -w[:] -eu <<<{} sed -E 's/(...).*/\1/' \; -dd
@@ -2041,9 +2040,9 @@ bash $ <<<$(<ab.json jtc -w'<children>l:[:]' -j) jtc -w[:] -eu <<<{} sed -E 's/(
 ..walk_interleaved_(), instance: 0, iterators: 0
 .write_json(), outputting json to <stdout>
 {}
-bash $ 
+bash $
 ```
-\- It did not work, because `jtc` received at the input only just this `{}`. Obviously `<<<{}` was interpolated by shell -  
+\- It did not work, because `jtc` received at the input only just this `{}`. Obviously `<<<{}` was interpolated by shell -
 `jtc` got that, thus, we have to quote it:
 ```
 bash $ <ab.jsonbash $ <<<$(<ab.json jtc -w'<children>l:[:]' -j) jtc -w[:] -eu '<<<{}' sed -E 's/(...).*/\1/' \; -dd
@@ -2081,10 +2080,10 @@ error: shell returned error (512)
    "Robert",
    "Lila"
 ]
-bash $ 
+bash $
 ```
-\- Now it did not work, because `jtc` received `sed`'s argument without single quotations (again those have been eaten by bash 
-before passing to `jtc` -  something `jtc` is unable to control - shell arguments evaluation of its own arguments). Thus, 
+\- Now it did not work, because `jtc` received `sed`'s argument without single quotations (again those have been eaten by bash
+before passing to `jtc` -  something `jtc` is unable to control - shell arguments evaluation of its own arguments). Thus,
 let's double quote it now:
 ```
 bash $ <<<$(<ab.json jtc -w'<children>l:[:]' -j) jtc -w[:] -eu '<<<{}' sed -E "'s/(...).*/\1/'" \; -dd
@@ -2128,22 +2127,22 @@ bash $ <<<$(<ab.json jtc -w'<children>l:[:]' -j) jtc -w[:] -eu '<<<{}' sed -E "'
    "Rob",
    "Lil"
 ]
-bash $ 
+bash $
 ```
 Now it worked!
 
 Actually, the whole _cli_ could have been coded like this:
 ```
-bash $ <<<$(<ab.json jtc -w'<children>l:[:]' -j) jtc -w[:] -eu '<<<{} sed -E "s/(...).*/\1/";' 
+bash $ <<<$(<ab.json jtc -w'<children>l:[:]' -j) jtc -w[:] -eu '<<<{} sed -E "s/(...).*/\1/";'
 [
    "Oli",
    "Rob",
    "Lil"
 ]
-bash $ 
+bash $
 ```
-Of course, the above way of solving the ask is entirely academic - it's always best to avoid using _shell cli_ evaluation and 
-default to it only as a last resort.  
+Of course, the above way of solving the ask is entirely academic - it's always best to avoid using _shell cli_ evaluation and
+default to it only as a last resort.
 A much better (efficient) way achieving the same ask would be to use RE and template interpolation:
 ```
 bash $ <<<$(<ab.json jtc -w'<children>l:[:]' -j) jtc -w'<(...)>R:' -T'"{$1}"' -j
@@ -2152,28 +2151,28 @@ bash $ <<<$(<ab.json jtc -w'<children>l:[:]' -j) jtc -w'<(...)>R:' -T'"{$1}"' -j
    "Rob",
    "Lil"
 ]
-bash $ 
+bash $
 ```
 
 
-### Use of mixed arguments for `-i`, `-u`, `-c` 
+### Use of mixed arguments for `-i`, `-u`, `-c`
 options `-c`, `-u`, `-i` allow two *kinds* of their arguments:
 1. static JSONs (i.e., `<file>`, `<JSON>`)
 2. walk-path (i.e., `<walk-path>`)
 
-\- when those used together, namely a `<walk-path>` argument(s) follows either of statics, e.g.: 
+\- when those used together, namely a `<walk-path>` argument(s) follows either of statics, e.g.:
 ```
 jtc -u file.json -u'[Root][:]'`
 ```
 then all `<walk-path>` arguments (here `[Root][:]`) apply onto the static argument (here `file.json`).
-\- When both kinds of arguments are used together, then only one (the first) static JSON argument is accepted, while 
+\- When both kinds of arguments are used together, then only one (the first) static JSON argument is accepted, while
 multiple walk-path may be given
 \- if `<walk-path>` arguments are given without preceding static JSON, then walk-path are applied onto the input (source) JSON
 
-That rule is in play to facilitate a walking capability over the specified static JSONs. Though be aware: in any case _all specified 
+That rule is in play to facilitate a walking capability over the specified static JSONs. Though be aware: in any case _all specified
 `<walk-path>` arguments will be processed in a consecutive order, one by one (i.e., interleaving never occurs)_.
 
-(Also, see 
+(Also, see
 [operations with cross referenced lookups](https://github.com/ldn-softdev/jtc/blob/master/User%20Guide.md#cross-referenced-lookups)
 )
 
@@ -2183,8 +2182,8 @@ options `-u`, `-i` when used together with `-e` also allow specifying multiple i
 1. first option occurrence must prove a shell cli line, terminated with `;`
 2. all the subsequent option usages must provide `<walk-path>` type of argument, which let specifying source(s) of interpolation.
 However, in the case if mixed option arguments usage is detected (in presence of `-e`), then the semantic of the `jtc` arguments would
-be like this (e.g., for option `-u`):  
-`jtc -w'<dst>' -eu <shell cli ...> \; -u'<src>'`  
+be like this (e.g., for option `-u`):
+`jtc -w'<dst>' -eu <shell cli ...> \; -u'<src>'`
 Here, both `<dst>` and `<src>` walks the same input JSON. _Shell cli_ evaluation / interpolation occurs from walking `<src>`
 That way it's possible to decouple source(s) (of interpolation) from the destination(s): all trailing (subsequent) arguments of `-u`
 will be used in every shell evaluation (interpolating respective JSON elements), while arguments pointed by (all) `-w` option(s)
@@ -2204,7 +2203,7 @@ bash $ <<<$(<ab.json jtc -ei '<<<{{}}' tr '[:lower:]' '[:upper:]' \; -i'<name>l:
 "children": [ "IVAN" ]
 "name": "Jane"
 "children": [ "Robert", "Lila", "JANE" ]
-bash $ 
+bash $
 ```
 - there, the source(s) of shell interpolation were `name` records (provided with `-i'<name>l:'`), while the destination were `children`
 (given with `-w'<children>l:'`)
@@ -2216,33 +2215,33 @@ In case if only a single option instance (`-eu`/`-ei`) is used, then both the so
 ### Summary of modes of operations
 `jtc` supports multiple update (and insertion) modes, at first it's easy to get confused, so let's recap here all the options:
 
-##### 1. _Update JSON from other locations of the same JSON:_  
-`<file.json jtc -w<dst_wlk> -u<src_wlk>`  
-\- destination(s) (in `file.json` pointed by `dst_wlk`) is updated from `src_wlk` of the same file (JSON) 
+##### 1. _Update JSON from other locations of the same JSON:_
+`<file.json jtc -w<dst_wlk> -u<src_wlk>`
+\- destination(s) (in `file.json` pointed by `dst_wlk`) is updated from `src_wlk` of the same file (JSON)
 
 ##### 2. _Update JSON with a static JSON (either from file, or a spelled literally):_
-`<file.json jtc -w<dst_wlk> -u<static_json>`  
+`<file.json jtc -w<dst_wlk> -u<static_json>`
 \- destination(s) (in `file.json` pointed by `dst_wlk`) is updated from `static_json` (a file, or a literal JSON)
 
 ##### 3. _Update JSON from some locations of a static JSON (either from file, or a spelled literally):_
-`<file.json jtc -w<dst_wlk> -u<static_json> -u<src_wlk>`  
+`<file.json jtc -w<dst_wlk> -u<static_json> -u<src_wlk>`
 \- destination(s) (in `file.json` pointed by `dst_wlk`) is updated from `src_wlk` walked `static_json`
 
 ##### 4. _Update JSON with the transformed JSON elements via shell cli:_
-`<file.json jtc -w<dst_wlk> -eu <cli> \;`  
+`<file.json jtc -w<dst_wlk> -eu <cli> \;`
 \- destination(s) (in `file.json` pointed by `dst_wlk`) is updated from shell-evaluation of `cli`. `cli` here is subjected for
 interpolation from namespaces and/or JSON elements pointed by `dst_wlk` itself.
 
 ##### 5. _Update JSON from some locations of the transformed JSON via shell cli:_
-`<file.json jtc -w<dst_wlk> -e -u <cli> \; -u<src_wlk>`  
-\- destination(s) (in `file.json` pointed by `dst_wlk`) is updated from shell-evaluated `cli`. `cli` here is subjected for 
+`<file.json jtc -w<dst_wlk> -e -u <cli> \; -u<src_wlk>`
+\- destination(s) (in `file.json` pointed by `dst_wlk`) is updated from shell-evaluated `cli`. `cli` here is subjected for
 interpolation from namespaces and/or JSON elements pointed by `src_wlk` walking `file.json`.
 
 _NOTE: if destination walk (`-w`) is pointing to the root of JSON then it can be entirely dismissed (in any of the above
 examples) - root is always assumed_
 
 ## Comparing JSONs
-`-c` allows comparing JSONs (or JSONs element pointed by walk-paths) - `jtc` will display JSON delta (diffs) between compared JSONs. 
+`-c` allows comparing JSONs (or JSONs element pointed by walk-paths) - `jtc` will display JSON delta (diffs) between compared JSONs.
 Let's compare `phone` records from the first and  the second entries of the address book:
 ```
 bash $ <ab.json jtc -w'[Directory][0][phone]' -c'[Directory][1][phone]' -l
@@ -2284,7 +2283,7 @@ bash $ echo $?
 4
 bash $
 ```
-If multiple pairs of JSONs compared, zero code is returned only when all compared JSON pairs are equal. 
+If multiple pairs of JSONs compared, zero code is returned only when all compared JSON pairs are equal.
 
 
 ### Comparing JSON schemas
@@ -2301,7 +2300,7 @@ bash $ <<<$(<ab.json jtc -w'<Ivan>[-1] [children]' -i'"Norma"') jtc -w'<Ivan>[-1
    ]
 }
 "json_2": {}
-bash $ 
+bash $
 ```
 
 However, their schemas would be the same. To compare schemas of two JSONs (loosely, with applied exemption on checking leaves data types),
@@ -2330,7 +2329,7 @@ attempting to print a label of the root always results in the exception:_
 ```
 bash $ <ab.json jtc -w'<>k'
 jtc json exception: walk_root_has_no_label
-bash $ 
+bash $
 ```
 
 ## Interpolation
@@ -2350,14 +2349,14 @@ shell cli) of tokens `{}` or `{{}}` will trigger interpolation:
 
 
 ### Interpolation types
-The difference between single `{}` and double `{{}}` notations: 
+The difference between single `{}` and double `{{}}` notations:
 - double notation `{{..}}` interpolate JSON elements exactly, so it's always a safe type
 - a single notation `{..}` interpolate _JSON strings_, _JSON arrays_, _JSON objects_ differently:
-  * when interpolating _JSON string_, the outer quotation marks are dropped, e.g., instead of `"blah"`, it will be interpolated as 
+  * when interpolating _JSON string_, the outer quotation marks are dropped, e.g., instead of `"blah"`, it will be interpolated as
   `blah`. Thus, it makes sense to use this interpolation inside double quotations (the interpolated value still has to be a valid JSON)
-  * when interpolating _JSON array_, then enclosing brackets `[`, `]` are dropped (allows extending arrays); e.g., `[1,2,3]` 
+  * when interpolating _JSON array_, then enclosing brackets `[`, `]` are dropped (allows extending arrays); e.g., `[1,2,3]`
   will be interpolated as `1,2,3` (which is invalid JSON), thus to keep it valid the outer brackets must be provided - `-T'[ {} ]'`
-  * when interpolating _JSON object_, then enclosing braces `{`, `}` are dropped (allows extending objects), e.g., `{"pi":3.14}` 
+  * when interpolating _JSON object_, then enclosing braces `{`, `}` are dropped (allows extending objects), e.g., `{"pi":3.14}`
   will be interpolated as `"pi": 3.14`, so to keep it valid the outer braces must be provided, e.g., `-T{ {}, "key": "new" }`
     * when an object is attempted interpolation but resulting JSON fails, then the object will be attempted interpolation as an array
     (i.e. only object's values will be interpolated) - that way it's possible to convert _JSON objects_ into _arrays_
@@ -2373,7 +2372,7 @@ bash $ <<<'{ "label": "value" }' jtc -w'<label>l<>k' -u'<label>l<L>k' -T'"new {L
 {
    "new label": "value"
 }
-bash $ 
+bash $
 ```
 Here's an illustration when double braces are handier (e.g., swapping around labels and values):
 ```
@@ -2388,11 +2387,11 @@ bash $ <<<$JSN jtc -i'[:]<Key>k<Val>v' -T'{ "{Val}": {{Key}} }' -p
    "3.14": "pi",
    "irrational": "type"
 }
-bash $ 
+bash $
 ```
 
 An array interpolation using a single brace notation `{..}` is handy when there's a need extending the array _during_
-interpolation. 
+interpolation.
 There's a special case though - template-extending of an empty array. Let's consider a following example:
 ```
 bash $ JSN='[ {"args": [123],"Func": "x + y"}, { "args":[], "Func":"a * b" }  ]'
@@ -2409,7 +2408,7 @@ bash $ <<<$JSN jtc
       "args": []
    }
 ]
-bash $ 
+bash $
 ```
 And the ask here would be to augment all arrays in each `args` with the arguments from respective `Func`:
 ```
@@ -2431,7 +2430,7 @@ bash $ <<<$JSN jtc -w'[:][args]' -u'[:][Func]<(\w+)[ +*]+(\w+)>R[-1][args]' -T'[
       ]
    }
 ]
-bash $ 
+bash $
 ```
 
 When interpolating the second record, the interpolation in fact, would result in the invalid JSON: the _array_ in `args` is empty
@@ -2444,7 +2443,7 @@ of enumerations occurring over of either of `,` or `;`
 
 
 ### Namespaces with interleaved walks
-When multiple _interleaved_ walks (`-w`) present (obviously there must be multiple walks - a single one cannot be _interleaved_), 
+When multiple _interleaved_ walks (`-w`) present (obviously there must be multiple walks - a single one cannot be _interleaved_),
 they populate namespaces in the order the walks appear:
 ```
 bash $ <ab.json jtc -x[0][:] -y'[name]<pnt>v' -y'[children][:]<chld>v' -T'{ "Parent": {{pnt}}, "child": {{chld}} }' -r
@@ -2454,24 +2453,24 @@ bash $ <ab.json jtc -x[0][:] -y'[name]<pnt>v' -y'[children][:]<chld>v' -T'{ "Par
 { "Parent": "Jane", "child": "Olivia" }
 { "Parent": "Jane", "child": "Robert" }
 { "Parent": "Jane", "child": "Lila" }
-bash $ 
+bash $
 ```
 That is a correct result (though might not reflect what possibly was intended), let review the result:
 1. first line contains only result `"John"` - because template interpolation here failed (namespace `chld` does not yet exist yet,
 thus the resulting template is _invalid JSON_) hence source walk is used / printed last walked JSON value
 2. upon next (_interleaved_) walk, we see a correct result of template interpolation: `Parent`'s and `child`'s records are filled right
 (template is a _valid JSON_ here)
-3. in the third line, the result is also correct, albeit might be not the expected one - upon next _interleaved_ walk, the 
+3. in the third line, the result is also correct, albeit might be not the expected one - upon next _interleaved_ walk, the
 namespace `pnt` is populated with `"Ivan"`, but the namespace `chld` still carries the old result.
 4. _etc._
 
 By now it should be clear why is such result.
 
-Going by the notion of the provided template, apparently, the expected result were to have all records pairs for each person with 
+Going by the notion of the provided template, apparently, the expected result were to have all records pairs for each person with
 each own child. That way, for example, `Ivan` should not be even listed (he has no children), `John`'s record should appear only
 once and `Jane` should have 2 records (she has 2 kids).
 
-The situation could be easily rectified if for each walk we use own template and assign a dummy one for the first one: 
+The situation could be easily rectified if for each walk we use own template and assign a dummy one for the first one:
 ```
 bash $ <ab.json jtc -x[0][:] -y'[name]<pnt>v' -T'""' -y'[children][:]<chld>v' -T'{ "Parent": {{pnt}}, "child": {{chld}} }' -r
 ""
@@ -2480,7 +2479,7 @@ bash $ <ab.json jtc -x[0][:] -y'[name]<pnt>v' -T'""' -y'[children][:]<chld>v' -T
 ""
 { "Parent": "Jane", "child": "Robert" }
 { "Parent": "Jane", "child": "Lila" }
-bash $ 
+bash $
 ```
 Now the result looks closer to the intended one (no records for `Ivan`, one for `John` and 2 for `Jane`, as expected). But what about
 those annoying empty _JSON strings_ `""`? Those will be gone if `-qq` option is thrown in:
@@ -2489,7 +2488,7 @@ bash $ <ab.json jtc -x[0][:] -y'[name]<pnt>v' -T'""' -y'[children][:]<chld>v' -T
 { "Parent": "John", "child": "Olivia" }
 { "Parent": "Jane", "child": "Robert" }
 { "Parent": "Jane", "child": "Lila" }
-bash $ 
+bash $
 ```
 \- that's a neat, though a [documented](https://github.com/ldn-softdev/jtc/blob/master/User%20Guide.md#unquoting-JSON-strings) trick
 
@@ -2499,7 +2498,7 @@ bash $ <ab.json jtc -w'[0][:][name]<pnt>v[-1][children][:]' -T'{ "Parent": {{pnt
 { "Parent": "John", "child": "Olivia" }
 { "Parent": "Jane", "child": "Robert" }
 { "Parent": "Jane", "child": "Lila" }
-bash $ 
+bash $
 ```
 
 
@@ -2517,13 +2516,13 @@ bash $ <<<$JSN jtc
       "milk": 0.90
    }
 }
-bash $ 
+bash $
 ```
 To achieve that, we need to memorize the value of index in the namespace first, then select a value from the list by the index:
 ```
 bash $ <<<$JSN jtc -w'[item]<idx>v[-1][list]><a{idx}' -l
 "milk": 0.90
-bash $ 
+bash $
 ```
 It should be quite easy to read/understand such walk path (predicated one is familiar with suffixes / directives). Let's see
 how the walk-path works in a slow-mo:
@@ -2531,13 +2530,13 @@ how the walk-path works in a slow-mo:
 ```
 bash $ <<<$JSN jtc -w'[item]'
 2
-bash $ 
+bash $
 ```
 2. `<idx>v` the directive memorizes selected value (`2`) in the namespace `idx`
 ```
 bash $ <<<$JSN jtc -w'[item]<idx>v'
 2
-bash $ 
+bash $
 ```
 3. `[-1]` steps up 1 level in the JSON tree off the current position (i.e., addresses the first parent of the `item` value) which is
 the root of the input JSON:
@@ -2551,7 +2550,7 @@ bash $ <<<$JSN jtc -w'[item]<idx>v[-1]'
       "milk": 0.90
    }
 }
-bash $ 
+bash $
 ```
 4. `[list]` selects the object value by label `list`:
 ```
@@ -2561,7 +2560,7 @@ bash $ <<<$JSN jtc -w'[item]<idx>v[-1][list]'
    "cheese": 2.90,
    "milk": 0.90
 }
-bash $ 
+bash $
 ```
 5. `><a{idx}` - a non-recursive search of atomic values (`><a`) indexed by a quantifier with the stored in the namespace `idx`
 (which is `2`) gives us the required value.
@@ -2570,12 +2569,12 @@ _Alternatively_, the same ask could be achieved using a slightly different query
 ```
 bash $ <<<$JSN jtc -w'[item]<idx>v[-1][list]>idx<t' -l
 "milk": 0.90
-bash $ 
+bash $
 ```
 - `>idx<t` lexeme here will utilize namespace `idx` to find the offset (index).
 
 There's a subtle difference how the lexeme `t` treats and uses referred namespace:
-- in `<..>t` notation, the lexeme always treats the value in the namespace as _JSON string_ and will try searching (recursively) a 
+- in `<..>t` notation, the lexeme always treats the value in the namespace as _JSON string_ and will try searching (recursively) a
 respective label. I.e., even if the value in the namespace is numerical value `0`, it will search for a label `"0"` instead
 - in `>..<t` notation, if the namespace holds a literal (i.e., a _JSON string_) value, then the lexeme will try matching the label
 (as expected);  however, if the namespace holds a numerical value (_JSON number_), then the value is used as a direct offset
@@ -2583,8 +2582,8 @@ in the searched JSON node
 
 
 ### Cross-referenced lookups
-One use-case that namespaces facilitate quite neatly, is when insert/update/purge/compare operation refer to different JSONs 
-(i.e., in [Use of mixed arguments](https://github.com/ldn-softdev/jtc/blob/master/User%20Guide.md#use-of-mixed-arguments-for--i--u--c) 
+One use-case that namespaces facilitate quite neatly, is when insert/update/purge/compare operation refer to different JSONs
+(i.e., in [Use of mixed arguments](https://github.com/ldn-softdev/jtc/blob/master/User%20Guide.md#use-of-mixed-arguments-for--i--u--c)
 types of operations) but one requires a reference from another.
 
 Say, we have 2 JSONs:
@@ -2608,7 +2607,7 @@ bash $ <main.json jtc
       "songs": []
    }
 ]
-bash $ 
+bash $
 ```
 2. `id.json`:
 ```
@@ -2627,15 +2626,15 @@ bash $ <id.json jtc
       "title": "The Show Must Go On"
    }
 ]
-bash $ 
+bash $
 ```
 
-The ask here is to insert songs titles from `id.json` into main.json cross-referencing respective `rec` to `id` values.  
+The ask here is to insert songs titles from `id.json` into main.json cross-referencing respective `rec` to `id` values.
 The way to do it:
-- first walk `main.json` finding and memorizing (each) `rec` value 
+- first walk `main.json` finding and memorizing (each) `rec` value
 - then, walk up to the `song` entry  (so that will be a destination pointer, where song needs to be inserted).
 
-The insert operation (`-i`) here would need to find `id` record in `id.json` using memorized (in the destination walk) namespace and 
+The insert operation (`-i`) here would need to find `id` record in `id.json` using memorized (in the destination walk) namespace and
 insert respective `title`:
 ```
 bash $ <main.json jtc -w'[:][rec]<Record>v[-1][songs]' -mi id.json -i'[id]:<Record>s[-1][title]'
@@ -2662,10 +2661,10 @@ bash $ <main.json jtc -w'[:][rec]<Record>v[-1][songs]' -mi id.json -i'[id]:<Reco
       ]
    }
 ]
-bash $ 
+bash $
 ```
 
-For each destination walk (`-w`) here, there will be a respective insert-walk (`-i`) (`-w` is walked first). When dst. walk 
+For each destination walk (`-w`) here, there will be a respective insert-walk (`-i`) (`-w` is walked first). When dst. walk
 finishes walking, the namespace will be populated with respective value from the `rec` entry. That value will be reused by insert-walk
 when walking its source JSON (`id.json`) with the lexeme `[id]:<Record>s` - that will find a respective `id`. The rest should be obvious
 by now.
@@ -2673,12 +2672,12 @@ by now.
 
 #### Cross-referenced purge
 `jtc` does not have a "walk" argument for `-p` (purge) operation (`-p` is a standalone option, when it's used only with `-w`
-it will purge every resulted/walked entry).  
-So, how to facilitate a cross-referenced purge then? (i.e., when purging ids are located in a separate file)  
+it will purge every resulted/walked entry).
+So, how to facilitate a cross-referenced purge then? (i.e., when purging ids are located in a separate file)
 
-The trick is to use a dummy `-u`/`-i` operation and apply `-p`.  
-When the cli is given in this notation:  
-`<<<dst.json jtc -w... -u <src.json> -u... -p`,  
+The trick is to use a dummy `-u`/`-i` operation and apply `-p`.
+When the cli is given in this notation:
+`<<<dst.json jtc -w... -u <src.json> -u... -p`,
 purging will be applied to walked destinations, but only predicated by a successful source walk:
 ```
 bash $ <main.json jtc -w'[:][rec]<Record>v[-1]' -u'[{"id":1}, {"id":3}]' -u'[id]:<Record>s' -p
@@ -2689,7 +2688,7 @@ bash $ <main.json jtc -w'[:][rec]<Record>v[-1]' -u'[{"id":1}, {"id":3}]' -u'[id]
       "songs": []
    }
 ]
-bash $ 
+bash $
 ```
 
 The "complemented" purge operation (i.e. when you want to delete everything except referenced) is facilitated using `-pp`:
@@ -2707,7 +2706,7 @@ bash $ <main.json jtc -w'[rec]:<Record>N:[-1]<Entry>v' -u'[1, 3]' -u'<Record>s' 
       "songs": []
    }
 ]
-bash $ 
+bash $
 ```
 \- memorizing the whole `Entry` is required because update operation w/o the template only replaced records (and purge everything else),
 but that's not the goal - goal is to retain all the entries, hence replacing the updating entries with the template for the entire entry.
@@ -2716,32 +2715,32 @@ but that's not the goal - goal is to retain all the entries, hence replacing the
 
 ## Templates
 Template, an argument to `-T` is a literal JSON optionally containing tokens for
-[interpolation](https://github.com/ldn-softdev/jtc/blob/master/User%20Guide.md#interpolation). Templates can be used upon walking, 
+[interpolation](https://github.com/ldn-softdev/jtc/blob/master/User%20Guide.md#interpolation). Templates can be used upon walking,
 insertion, updates and when comparing. The result of template interpolation still must be a valid JSON. If a template (`-T`) is given
 then it's a template value (after interpolation) will be used for the operations, not the source walk (unless the resulting template is
 invalid JSON, in such case the source walk will be used).
 
 When walking only is in process, then template interpolation occurs from the walk-path (`-w`):
 ```
-bash $ <ab.json jtc -w'[0][0]<number>l:' 
+bash $ <ab.json jtc -w'[0][0]<number>l:'
 "112-555-1234"
 "113-123-2368"
 bash $ <ab.json jtc -w'[0][0]<number>l:' -T'"+1 {}"'
 "+1 112-555-1234"
 "+1 113-123-2368"
-bash $ 
+bash $
 ```
 
 For the rest of operations (`-i`, `-u`, `-c`) templates are getting interpolated from walk-path of the operation argument itself and
 never from `-w`. The namespaces resulting from walking destinations (`-w`) are shared with source walks in operations (`-i`, `-u`, `-c`)
-\- that way 
+\- that way
 [cross-referenced lookups](https://github.com/ldn-softdev/jtc/blob/master/User%20Guide.md#cross-referenced-lookups)
  are possible.
 Logically, for each destination walk (`-w`) there will be a respective subsequent source walk (e.g.: `-c<src-walk>`), thus source walk
 may utilize the namespaces populated during destination walk (`-w`). Template-interpolation will be attempted only once source walk is
 successful
 
-Below is an example of updating the phone records for the first entry in the `Directory` (appending a country-code and 
+Below is an example of updating the phone records for the first entry in the `Directory` (appending a country-code and
 altering the `phone` label at the same time via template):
 ```
 bash $ <ab.json jtc -w'[0][0]<phone>l'
@@ -2766,13 +2765,13 @@ bash $ <<<$(<ab.json jtc -w'[0][0]<phone>l[:]' -pi'[0][0]<number>l:<val>v' -T'{ 
       "type": "mobile"
    }
 ]
-bash $ 
+bash $
 ```
 Explanations:
 - `-w'[0][0]<phone>l[:]'` - that's our destination which we will be updating (i.e., all phone records in the first `Directory` entry)
 - `-pi'[0][0]<number>l:<val>v'` - we'll walk (synchronously with `-w`) all the `number` records and memorize `number` values in the
 namespace `val`; option `-p` turns _insert_ operation into _move_
-- `-T'{ "phone number": "+1 {val}" }'` after each source walk argument in `-i`, a template interpolations occurs - a new 
+- `-T'{ "phone number": "+1 {val}" }'` after each source walk argument in `-i`, a template interpolations occurs - a new
 JSON entry is generated from the template and namespace `val` and the new entry is then used for insertion into the respective
 destination walk (`-w`). Thus using templates it becomes easy to transmute existing JSON into a new one.
 
@@ -2780,7 +2779,7 @@ destination walk (`-w`). Thus using templates it becomes easy to transmute exist
 ### Multiple templates and walks
 When multiple templates given and a number of walks (`-w<walk>`, or `-u<walk>`, `-i<walk>`) **is matching** the number of templates
 (i.e., more than one walk is present) then templates are pertain per each walk. In all other cases templates are applied in a
-round-robin fashion.  
+round-robin fashion.
 In the case when round-robin behavior is required when number of templates and walks matches, use `-nn` notation - it will ensure
 round-robin templates application onto sequential walks
 
@@ -2793,7 +2792,7 @@ bash $ <ab.json jtc -x[0][:] -y[name] -T'{"Person":{{}}}' -y[age] -T'{"Age":{{}}
 { "Age": 31 }
 { "Person": "Jane" }
 { "Age": 25 }
-bash $ 
+bash $
 bash $ <ab.json jtc -x[0][:] -y[name] -T'{"Person":{{}}}' -y[age] -T'{"Age":{{}}}' -rn
 { "Person": "John" }
 { "Person": "Ivan" }
@@ -2808,7 +2807,7 @@ bash $ <ab.json jtc -x[0][:] -y[name] -T'{"Person":{{}}}' -y[age] -T'{"Age":{{}}
 { "Age": 25 }
 { "Person": 31 }
 { "Age": 25 }
-bash $ 
+bash $
 
 ```
 The mess in the above's last example is explained by `-nn` usage: templates are forced to apply in the round-robin fashion
@@ -2820,7 +2819,7 @@ bash $ <<<'[1,2,3,4,5,6,7,8,9,10]' jtc -w[:] -T'""' -T{} -T'""' -qq
 2
 5
 8
-bash $ 
+bash $
 ```
 \- in the above example printed every 3rd element from source JSON starting from the 2nd one (recall: when unquoting an empty
 JSON string ("") the resulted blank lines are not getting printed).
@@ -2847,18 +2846,18 @@ That was an example of _stringification_ of a JSON value, now let's do a reverse
 ```
 bash $ <<<'["a", "b"]' jtc -T'>>{{}}<<' | jtc -T'[ <{{}}>, "c"]' -r
 [ "a", "b", "c" ]
-bash $ 
+bash $
 ```
 \- the above example sports _jsonization_ of the previously _stringified JSON_ while extending resulting JSON array at the same time
 
 
 ## Processing multiple input JSONs
-Normally `jtc` would process only a single input JSON. If multiple input JSONs given - the fist JSON will be processed and the 
+Normally `jtc` would process only a single input JSON. If multiple input JSONs given - the fist JSON will be processed and the
 rest of the inputs will be silently ignored:
 ```
 bash $ <<<'[ "1st json" ] { "2nd": "json" } "3rd json"' jtc -r
 [ "1st json" ]
-bash $ 
+bash $
 ```
 Couple options allow altering the behavior and process all the input JSONs:
 
@@ -2870,7 +2869,7 @@ bash $ <<<'[ "1st json" ] { "2nd": "json" } "3rd json"' jtc -ar
 [ "1st json" ]
 { "2nd": "json" }
 "3rd json"
-bash $ 
+bash $
 ```
 \- respected processing (of all given options) will occur for all of the input JSONs:
 ```
@@ -2879,7 +2878,7 @@ bash $ <<<'[ "1st json" ] { "2nd": "json" } "3rd json"' jtc -a -w'<json>R'
 "json"
 notice: input atomic JSON is non-iterable, ignoring all walk-paths (-w)
 "3rd json"
-bash $ 
+bash $
 ```
 All the input JSONs will be processed as long they are valid - processing will stops upon parsing failure:
 ```
@@ -2892,7 +2891,7 @@ bash $ <<<'[ "1st json" ] { "2nd": json" } "3rd json"' jtc -ad
 .parsejson(), exception locus: [ "1st json" ] { "2nd": j
 .location_(), exception spot: ------------------------>| (offset: 24)
 jtc json exception: expected_json_value
-bash $ 
+bash $
 ```
 
 ### Wrap all processed JSONs
@@ -2906,9 +2905,9 @@ notice: input atomic JSON is non-iterable, ignoring all walk-paths (-w)
    "json",
    "3rd json"
 ]
-bash $ 
+bash $
 ```
-option `-J` also implicitly imposes `-j` thus it could be used safely even with a single JSON at the input with the same effect.  
+option `-J` also implicitly imposes `-j` thus it could be used safely even with a single JSON at the input with the same effect.
 Though, when walking multiple input JSONs, each of the option would have its own effect, this example clarifies:
 ```
 bash $ jtc -w'[0][:][name]' -aj ab.json ab.json
@@ -2922,7 +2921,7 @@ bash $ jtc -w'[0][:][name]' -aj ab.json ab.json
    "Ivan",
    "Jane"
 ]
-bash $ 
+bash $
 bash $ jtc -w'[0][:][name]' -J ab.json ab.json
 [
    "John",
@@ -2932,7 +2931,7 @@ bash $ jtc -w'[0][:][name]' -J ab.json ab.json
    "Ivan",
    "Jane"
 ]
-bash $ 
+bash $
 bash $ jtc -w'[0][:][name]' -Jj ab.json ab.json
 [
    [
@@ -2946,10 +2945,10 @@ bash $ jtc -w'[0][:][name]' -Jj ab.json ab.json
       "Jane"
    ]
 ]
-bash $ 
+bash $
 ```
 
-_Note: `jtc` supports unlimited number of files that can be supplied as standalone arguments (after all options given). When 
+_Note: `jtc` supports unlimited number of files that can be supplied as standalone arguments (after all options given). When
 multiple input files are given, options `-a` is assumed_
 
 
@@ -2959,11 +2958,11 @@ multiple input files are given, options `-a` is assumed_
 - _**streamed read**_
 
 In the _buffered read_ mode (which is default), entire file (or `<stdin>`) input is read into memory and only then JSON parsing is
-attempted (with all subsequent due processing).  
+attempted (with all subsequent due processing).
 In the _streamed read_ mode JSON parsing begins immediately as the the first character is read (so, no memory wasted to hold input JSON).
 
 The _streamed read_ is activated when:
-- option `-a` given *AND* input source is `<stdin>`  
+- option `-a` given *AND* input source is `<stdin>`
 - option `-J` overrides _streamed read_ (reverting to _buffered_): _streamed read_ might be endless, while option `-J` assumes a finite
 number of inputs to be processed and then displayed
 
@@ -2974,7 +2973,7 @@ a network-based streaming)
 We can see the difference in the parsing when debugging `jtc`:
 \- in a _buffered read_ mode, the debug will show the _parsing point_ with data after:
 ```
-bash $ <ab.json jtc -dddddd 
+bash $ <ab.json jtc -dddddd
 .read_inputs(), reading json from <stdin>
 ......parse_(), parsing point ->{|  "Directory": [|    {|       "name": "John",|       "ag...
 ......parse_(), parsing point ->"Directory": [|    {|       "name": "John",|       "age": ...
@@ -3001,7 +3000,7 @@ Here's an example of how _streamed read_ works in `jtc`:
 | bash $ nc -lk localhost 3000 | jtc -ra               | bash $ <ab.json jtc -w'<address>l:' | nc localhost 3 |
 | { "city": "New York", "postal code": 10012, "state": | 000                                                  |
 | "NY", "street address": "599 Lafayette St" }         | bash $                                               |
-| { "city": "Seattle", "postal code": 98104, "state":  | bash $ <ab.json jtc -w'<name>l:' -w'<name>l:[-1][pho | 
+| { "city": "Seattle", "postal code": 98104, "state":  | bash $ <ab.json jtc -w'<name>l:' -w'<name>l:[-1][pho |
 | "WA", "street address": "5423 Madison St" }          | ne]' | nc localhost 3000                             |
 | { "city": "Denver", "postal code": 80206, "state": " | bash $                                               |
 | CO", "street address": "6213 E Colfax Ave" }         | bash $ <ab.json jtc -w'<name>l:<N>v[-1][children]' - |
@@ -3020,7 +3019,7 @@ Here's an example of how _streamed read_ works in `jtc`:
 | }                                                    |                                                      |
 |                                                      |                                                      |
 ```
- 
+
 In the `Screen 1`, `jtc` listens to the stream data coming from `netcat` utility and process-prints (in a compact format) all
 the input JSONs. It will stop once `<stdin>` is closed, but `netcat` is run using `-k` option, which means _endlessly_.
 
@@ -3034,7 +3033,7 @@ line by line, while separating JSON values either with `,` or with `;` (`csv` fo
 
 There are couple tricks required to do so, but not difficult ones, so, let's walk it.
 
-Say, we want to dump into `csv` format following data from the `ab.json`:  
+Say, we want to dump into `csv` format following data from the `ab.json`:
 `name, city, postal code, state, street address`
 
 1. First let's just dump all those entries:
@@ -3055,7 +3054,7 @@ bash $ <ab.json jtc -rx[0][:] -y[name] -y[address][:]
 80206
 "CO"
 "6213 E Colfax Ave"
-bash $ 
+bash $
 ```
 \- not that difficult
 
@@ -3077,7 +3076,7 @@ bash $ <ab.json jtc -rx[0][:] -y[name] -y[address][:] -T'"{$?}, {}"'
 "John, New York, 10012, NY, 599 Lafayette St, Ivan, Seattle, 98104, WA, 5423 Madison St, Jane, Denver, 80206"
 "John, New York, 10012, NY, 599 Lafayette St, Ivan, Seattle, 98104, WA, 5423 Madison St, Jane, Denver, 80206, CO"
 "John, New York, 10012, NY, 599 Lafayette St, Ivan, Seattle, 98104, WA, 5423 Madison St, Jane, Denver, 80206, CO, 6213 E Colfax Ave"
-bash $ 
+bash $
 ```
 \- hmmm, but we need such line one per record and not like above
 
@@ -3103,7 +3102,7 @@ bash $ <ab.json jtc -rx[0][:] -y[name] -y[address][:] -y' ' -T'"{$?}, {}"'
 "Jane, Denver, 80206, CO"
 "Jane, Denver, 80206, CO, 6213 E Colfax Ave"
 { "address": { "city": "Denver", "postal code": 80206, "state": "CO", "street address": "6213 E Colfax Ave" }, "age": 25, "children": [ "Robert", "Lila" ], "name": "Jane", "phone": [ { "number": "358-303-0373", "type": "office" }, { "number": "333-638-0238", "type": "home" } ], "spouse": "Chuck" }
-bash $ 
+bash $
 ```
 \- that's better, now every 5th walk out of every 6 is what we need.
 
@@ -3113,7 +3112,7 @@ bash $ <ab.json jtc -rx[0][:] -y[name] -y[address][:] -y' ' -T'"{$?}, {}"' -x6/4
 "John, New York, 10012, NY, 599 Lafayette St"
 "Ivan, Seattle, 98104, WA, 5423 Madison St"
 "Jane, Denver, 80206, CO, 6213 E Colfax Ave"
-bash $ 
+bash $
 ```
 \- that is our required `CSV` format! Well, almost - every line is still a JSON string, but we can undress it with `-qq` option
 
@@ -3124,7 +3123,7 @@ name, city, postal, street
 John, New York, 10012, NY, 599 Lafayette St
 Ivan, Seattle, 98104, WA, 5423 Madison St
 Jane, Denver, 80206, CO, 6213 E Colfax Ave
-bash $ 
+bash $
 ```
 DONE.
 
@@ -3142,7 +3141,7 @@ bash $ <<<$dups jtc
    "string",
    null
 ]
-bash $ 
+bash $
 ```
 So, let's
 #### Remove duplicates
@@ -3154,9 +3153,9 @@ bash $ <<<$dups jtc -w'<>Q:' -p
    null,
    3.14
 ]
-bash $ 
+bash $
 ```
-Because switch `-p` is given, all the duplicate elements will be purged, thus leaving the list only with non-duplicate (unique) 
+Because switch `-p` is given, all the duplicate elements will be purged, thus leaving the list only with non-duplicate (unique)
 elements
 
 But there's a reverse action:
@@ -3167,19 +3166,19 @@ bash $ <<<$dups jtc -w'<>Q:' -pp
    "string",
    null
 ]
-bash $ 
+bash $
 ```
 That one is obvious - we just reversed the prior example.
 
 How about:
 #### Leave only those which have no duplicates
 ```
-bash $ <<<$dups jtc -w'<dup>Q:[^0]<dup>s:' -p 
+bash $ <<<$dups jtc -w'<dup>Q:[^0]<dup>s:' -p
 [
    true,
    3.14
 ]
-bash $ 
+bash $
 ```
 it's just a tiny bit more complex:
 - `<dup>Q:` - for each duplicate element, we'll memorize it into `.` namespace, then
@@ -3197,12 +3196,12 @@ bash $ <<<$dups jtc -w'<dup>Q:[^0]<dup>s:' -pp
    "string",
    null
 ]
-bash $ 
+bash $
 ```
 it's just a reverse action.
 
 **CAUTION:** _be aware that directives `<..>q`, `<..>Q` are dynamic types, which means they are exempted for cacheing,
-implying that on very big JSONs an **exponential decay** will become noticeable. Plus, both directives are quite memory hungry._  
+implying that on very big JSONs an **exponential decay** will become noticeable. Plus, both directives are quite memory hungry._
 Thus use them cautiously when dealing with big JSONs (around or above hundreds of thousand of nodes - subjected to a spec of your machine)
 
 
@@ -3211,14 +3210,14 @@ Counting any number of properties is JSON could be done using exteral `wc` unix 
 ```
 bash $ <ab.json jtc -w'<number>l:' | wc -l
        6
-bash $ 
+bash $
 ```
 
 The same is possible to achieve using only `jtc` capability - using `<..>I` lexeme:
 ```
 bash $ <ab.json jtc -w'<number>l:<cnt>I1' -T{cnt} -x/-1
 6
-bash $ 
+bash $
 ```
 - `<cnt>I1` will arrange a namespace var `cnt` counting values starting from `0` with increment of `1` upon each walk pass (iteration)
 - `-T{cnt}` will interpolate it
@@ -3228,7 +3227,7 @@ Say, now we want to count the same phone numbers, but for some reason starting f
 ```
 bash $ <ab.json jtc -w'<cnt:100>f[]<>F<number>l:<cnt>I1' -T{cnt} -x/-1
 106
-bash $ 
+bash $
 ```
 - `<cnt:100>f` will setup a fail-safe point at the same time initializing namespace `cnt` with value `100`
 - `[]` is a walk lexeme which is guaranteed to fail here (there are no empty lables), so, it will trigger a fail-stop, which will
@@ -3242,12 +3241,5 @@ bash $ <ab.json jtc -x'<phone>l:' -y'<home>:<hn>I1'  -y'<mobile>:<mn>I1' -T'{"to
    "total home numbers": 2,
    "total mobile numbers": 3
 }
-bash $ 
+bash $
 ```
-
-
-
-
-
-
-

--- a/User Guide.md
+++ b/User Guide.md
@@ -81,7 +81,7 @@
 ### Pretty printing
 if no argument given, `jtc` will expect an input JSON from the `<stdin>`, otherwise JSON is read from the file pointed by the argument.
 `jtc` will parse and validate input JSON and upon a successful validation will output:
-```
+```ShellSession
 bash $ <ab.json jtc
 {
    "Directory": [
@@ -161,7 +161,7 @@ bash $ <ab.json jtc
 bash $
 ```
 option `-t` controls the indentation of the pretty-printing format (default is 3 white spaces):
-```
+```ShellSession
 bash $ <ab.json jtc -t 10
 {
           "Directory": [
@@ -182,12 +182,12 @@ Majority of the examples and explanations in this document are based on the abov
 
 ### Compact printing
 option `-r` will instruct to display JSON in a compact (one-row) format:
-```
+```ShellSession
 bash $ <ab.json jtc -r
 { "Directory": [ { "address": { "city": "New York", "postal code": 10012, "state": "NY", "street address": "599 Lafayette St" }, "age": 25, "children": [ "Olivia" ], "name": "John", "phone": [ { "number": "112-555-1234", "type": "mobile" }, { "number": "113-123-2368", "type": "mobile" } ], "spouse": "Martha" }, { "address": { "city": "Seattle", "postal code": 98104, "state": "WA", "street address": "5423 Madison St" }, "age": 31, "children": [], "name": "Ivan", "phone": [ { "number": "273-923-6483", "type": "home" }, { "number": "223-283-0372", "type": "mobile" } ], "spouse": null }, { "address": { "city": "Denver", "postal code": 80206, "state": "CO", "street address": "6213 E Colfax Ave" }, "age": 25, "children": [ "Robert", "Lila" ], "name": "Jane", "phone": [ { "number": "358-303-0373", "type": "office" }, { "number": "333-638-0238", "type": "home" } ], "spouse": "Chuck" } ] }
 ```
 Option `-r` also can be used together with option `-t`, compare with the above output:
-```
+```ShellSession
 bash $ <ab.json jtc -rt0
 {"Directory":[{"address":{"city":"New York","postal code":10012,"state":"NY","street address":"599 Lafayette St"},"age":25,"children":["Olivia"],"name":"John","phone":[{"number":"112-555-1234","type":"mobile"},{"number":"113-123-2368","type":"mobile"}],"spouse":"Martha"},{"address":{"city":"Seattle","postal code":98104,"state":"WA","street address":"5423 Madison St"},"age":31,"children":[],"name":"Ivan","phone":[{"number":"273-923-6483","type":"home"},{"number":"223-283-0372","type":"mobile"}],"spouse":null},{"address":{"city":"Denver","postal code":80206,"state":"CO","street address":"6213 E Colfax Ave"},"age":25,"children":["Robert","Lila"],"name":"Jane","phone":[{"number":"358-303-0373","type":"office"},{"number":"333-638-0238","type":"home"}],"spouse":"Chuck"}]}
 ```
@@ -195,14 +195,14 @@ bash $ <ab.json jtc -rt0
 ### Printing JSON size
 JSON size is the total number of the JSON elements found within JSON, it could be printed using `-z`, the size appears after JSON
 is printed:
-```
+```ShellSession
 bash $ <ab.json jtc -r -z
 { "Directory": [ { "address": { "city": "New York", "postal code": 10012, "state": "NY", "street address": "599 Lafayette St" }, "age": 25, "children": [ "Olivia" ], "name": "John", "phone": [ { "number": "112-555-1234", "type": "mobile" }, { "number": "113-123-2368", "type": "mobile" } ], "spouse": "Martha" }, { "address": { "city": "Seattle", "postal code": 98104, "state": "WA", "street address": "5423 Madison St" }, "age": 31, "children": [], "name": "Ivan", "phone": [ { "number": "273-923-6483", "type": "home" }, { "number": "223-283-0372", "type": "mobile" } ], "spouse": null }, { "address": { "city": "Denver", "postal code": 80206, "state": "CO", "street address": "6213 E Colfax Ave" }, "age": 25, "children": [ "Robert", "Lila" ], "name": "Jane", "phone": [ { "number": "358-303-0373", "type": "office" }, { "number": "333-638-0238", "type": "home" } ], "spouse": "Chuck" } ] }
 size: 56
 bash $
 ```
 if size only required, then use `-zz` option:
-```
+```ShellSession
 bash $ <ab.json jtc -zz
 56
 bash $
@@ -211,14 +211,14 @@ bash $
 ### Validating JSON
 When JSON is read (from a file, or from `stdin`), it get parsed and validated. If an invalid JSON is detected, the short exception
 message will be displayed, e.g,:
-```
+```ShellSession
 bash $ <ab.json jtc
 jtc json exception: unexpected_end_of_line
 bash $
 ```
 though the message let us know that there's a problem with the input JSON, it not very informative with regard whereabouts the
 the problem. An easy way to see the spot where the problem and its locus is via debug (`-d`):
-```
+```ShellSession
 bash $ <ab.json jtc -d
 .read_inputs(), reading json from <stdin>
 .parsejson(), exception locus: ... Ave",|          "state": "CO,|          "postal code": 80206...
@@ -234,7 +234,7 @@ To fix that, the missing quotation mark to be added
 ### Forcing strict solidus parsing
 JSON specification allows escaping solidus (`/`) optionally. By default, `jtc` is relaxed w.r.t. solidus notation - it admits
 both unescaped and escaped appearances:
-```
+```ShellSession
 bash $ <<<'{ "escaped": "\/", "unescaped": "/" }' jtc
 {
    "escaped": "\/",
@@ -244,7 +244,7 @@ bash $
 ```
 If there's a need for a strict solidus parsing, option `-q` facilitates the need. It also will throw an exception upon facing
 a non-escaped notation:
-```
+```ShellSession
 bash $ <<<'{ "escaped": "\/", "unescaped": "/" }' jtc -q -d
 .read_json(), start parsing json from <stdin>
 .read_json(), exception locus: { "escaped": "\/", "unescaped": "/" }|
@@ -256,7 +256,7 @@ bash $
 ### Unquoting JSON strings
 If a JSON itself (or a result of JSON walking) is a single JSON string, then sometimes there's a need to unquote it
 (especially handy it comes if the string itself is an embedded JSON). `-qq` allows unquoting it, here are a few examples:
-```
+```ShellSession
 bash $ <<<'"{ \"JSON\": \"example of an embedded JSON\" }"' jtc
 "{ \"JSON\": \"example of an embedded JSON\" }"
 bash $
@@ -277,7 +277,7 @@ bash $
 ```
 
 When unquoting an empty _JSON string_ (`""`) the resulted blank lines are not even printed:
-```
+```ShellSession
 bash $ <<<'[null, "", true]' jtc -w[:] -qq
 null
 true
@@ -294,7 +294,7 @@ option `-qq` is silently ignored
 ### Stringifying JSON
 An opposite request is to string-quote a JSON itself (e.g. if you like to embed JSON as a string into another JSON). This is
 achieved with option notation `-rr`:
-```
+```ShellSession
 bash $ <<<'[ "JSON", "example" ]' jtc
 [
    "JSON",
@@ -317,7 +317,7 @@ Whenever there's a need to print only some or multiple JSON elements, walk-paths
 offsets are always enclosed into square brackets `[`,`]`, selecting JSON elements always begins from the root.
 Both arrays and objects can be subscripted using numerical offset, though it's best to utilize literal offsets to subscript objects.
 E.g. let's select `address` of the 2nd (all the indices in the walk-path are zero-based) record in the above JSON:
-```
+```ShellSession
 bash $ <ab.json jtc -w'[Directory][1][address]'
 {
    "city": "Seattle",
@@ -329,7 +329,7 @@ bash $
 ```
 or, equally could be done like in below example, but the former syntax is preferable (for your own good - when giving indices you'd need
 to _guess_ the index of a labeled entry, which might be prone to mistakes):
-```
+```ShellSession
 bash $ <ab.json jtc -w'[0][1][0]'
 {
    "city": "Seattle",
@@ -343,14 +343,14 @@ bash $
 #### Selecting multiple subscripted JSON elements
 if a numerical subscript is prepended with `+`, then the indexed and all subsequent subscripted elements will be selected as well
 (a.k.a _iterable_ lexeme), e.g., a following example prints all the names out of the address book, starting from the 2nd record:
-```
+```ShellSession
 bash $ <ab.json jtc -w'[Directory][+1][name]'
 "Ivan"
 "Jane"
 bash $
 ```
 Any numerical offset could be subscripted that way, and any number of such lexemes could appear in the walk-path, e.g.:
-```
+```ShellSession
 bash $ <ab.json jtc -w'[Directory][+0][phone][+1][number]'
 "113-123-2368"
 "223-283-0372"
@@ -362,7 +362,7 @@ the 2nd entry (`[+1]`)
 
 The same way object elements could be subscripted, here's an example where all address entries starting from the 2nd one are printed,
 each one stating from the 3rd entry:
-```
+```ShellSession
 bash $ <ab.json jtc -w'[Directory][+1][address][+2]'
 "WA"
 "5423 Madison St"
@@ -387,7 +387,7 @@ Thus, multiple notations with the same semantics are possible, e.g.:
 - `[-2:]` will select last 2 elements in the collection
 
 E.g., let's print all phone numbers for the last 2 records in the `Directory`:
-```
+```ShellSession
 bash $ <ab.json jtc -w'[Directory][-2:][phone][:][number]'
 "273-923-6483"
 "223-283-0372"
@@ -403,13 +403,13 @@ from the node in JSON where a prior lexeme has stopped.
 
 By default (if no one-letter suffix is given), a search lexeme will perform a search of _JSON string_ values only (i.e., it won't match
 _JSON numerical_ or _JSON boolean_ or _JSON null_ values). E.g., following search finds a match:
-```
+```ShellSession
 bash $ <ab.json jtc -w'<New York>'
 "New York"
 bash $
 ```
 while this one doesn't (the string value `New York` is found only in the first `Directory` record):
-```
+```ShellSession
 bash $ <ab.json jtc -w'[Directory][1:]<New York>'
 bash $
 ```
@@ -417,7 +417,7 @@ bash $
 #### Searching JSON with RE
 Optionally, search lexemes may accept one-letter suffixes: a single character following the lexeme's closing bracket.
 These suffixes alter the meaning of the search, e.g. suffix `R` instruct to perform a regex search among string values:
-```
+```ShellSession
 bash $ <ab.json jtc -w'<^N>R'
 "New York"
 bash $
@@ -447,7 +447,7 @@ Also, all following RE grammars are supported:
 Only the first specified grammar is parsed and is in effect (in case multiple given).
 All the trailing special symbols will be trimmed after RE parsing (i.e. they are not part of the RE search expression).
 E.g., the above example with options `\I` and `\P` (ignore case and use _egrep_ grammar) looks like this:
-```
+```ShellSession
 bash $ <ab.json jtc -w'<^n\I\P>R'
 "New York"
 bash $
@@ -562,7 +562,7 @@ for a shell evaluation.
 
 ##### Dynamic lookup using directives `-v` and `-k`
 Say, we have a following JSON:
-```
+```ShellSession
 bash $ <<<'{ "item": "bread", "list":{ "milk": 0.90, "bread": 1.20 } }' jtc
 {
    "item": "bread",
@@ -575,7 +575,7 @@ bash $
 ```
 the ask here is to retrieve a value from `list` defined by `item` - that would require a cross-reference lookup.
 Using namespaces it becomes a trivial task:
-```
+```ShellSession
 bash $ JSN='{ "item": "bread", "list":{ "milk": 0.90, "bread": 1.20 } }'
 bash $ <<<$JSN jtc -w'[item]<itm>v[^0]<itm>t'
 1.20
@@ -588,7 +588,7 @@ in the namespace `itm` (which is `bread`)
 Similar way labels/indices could be accessed and stored in the namespaces - using directive `k`. The directive lets reinterpreting
 label/index of the currently walked JSON element and treat it as a _JSON string_ / _JSON number_ value respectively.
 Say, we want to list all labels in the `address` record:
-```
+```ShellSession
 bash $ <ab.json jtc -w'<address>l[:]<>k'
 "city"
 "postal code"
@@ -611,7 +611,7 @@ into the _walk-path_.
 Let's break it down:
 
 Say, we want to list all `mobile` phone records (let's do it along with names of phone holders):
-```
+```ShellSession
 bash $ <ab.json jtc -w'[0][:][name]' -w'[0][:][phone]<mobile>[-1]' -r
 "John"
 { "number": "112-555-1234", "type": "mobile" }
@@ -622,7 +622,7 @@ bash $
 ```
 As it appears, `Jane` has no mobile phone, but then our requirement is enhanced: for those who do not have a `mobile`, let's list
 the first available phone from the records (there a `<>f` directive comes to a rescue):
-```
+```ShellSession
 bash $ <ab.json jtc -w'[0][:][name]' -w'[0][:][phone][0] <>f [-1]<mobile>[-1]' -r
 "John"
 { "number": "112-555-1234", "type": "mobile" }
@@ -656,7 +656,7 @@ Thus, we need to build a single path, which will find the `name`, then inspect `
 
 We can do it in steps:
 1. let's get to the `name`s first and memorize those:
-```
+```ShellSession
 bash $ <ab.json jtc -x'[0][:][name]<person>v'
 "John"
 "Ivan"
@@ -664,7 +664,7 @@ bash $ <ab.json jtc -x'[0][:][name]<person>v'
 bash $
 ```
 2. Now let's inspect a sibling record `children`:
-```
+```ShellSession
 bash $ <ab.json jtc -x'[0][:][name]<person>v [-1][children]'
 [
    "Olivia"
@@ -677,7 +677,7 @@ bash $ <ab.json jtc -x'[0][:][name]<person>v [-1][children]'
 bash $
 ```
 3. so far so good, but we need to engage _fail-safe_ to facilitate the requirement to classify those records as `true` / `false`:
-```
+```ShellSession
 bash $ <ab.json jtc -x'[0][:][name]<person>v [-1][children]<kids:false>f[0]<kids:true>v'
 "Olivia"
 []
@@ -689,7 +689,7 @@ bash $
 with `true` value
 
 4. finally, we need to interpolate preserved namespaces for our final / required output:
-```
+```ShellSession
 bash $ <ab.json jtc -x'[0][:][name]<person>v [-1][children]<kids:false>f[0]<kids:true>v' -T'{"{person} has children":{kids}}' -r
 { "John has children": true }
 { "Ivan has children": false }
@@ -699,7 +699,7 @@ bash $
 
 
 Now, let's consider another example. Say, we have a following JSON:
-```
+```ShellSession
 bash $ JSN='[ { "ip": "1.1.1.1", "name": "server" }, { "ip": "1.1.1.100" }, { "ip": "1.1.1.2", "name": "printer" } ]'
 bash $ <<<$JSN jtc
 [
@@ -719,7 +719,7 @@ bash $
 ```
 How do we list only those records which don't have `name` and skip those which do? Well, one apparent solution then would be
 to walk all those entries, which do have `name` labels and purge them:
-```
+```ShellSession
 bash $ <<<$JSN jtc -w'<name>l:[-1]' -p
 [
    {
@@ -731,7 +731,7 @@ bash $
 But what if we want to walk them instead of purging (e.g., for reason of template-interpolating the entries at the output)?
 The prior solution would require piping the output to the next `jtc` cli, however, it's possible to achieve the same using this
 simple query:
-```
+```ShellSession
 bash $ <<<$JSN jtc -w'[:]<>f[name]<>F'
 {
    "ip": "1.1.1.100"
@@ -739,7 +739,7 @@ bash $ <<<$JSN jtc -w'[:]<>f[name]<>F'
 bash $
 ```
 Without `<>F` directive, the walk would look like:
-```
+```ShellSession
 bash $ <<<$JSN jtc -w'[:]<>f[name]'
 "server"
 {
@@ -754,7 +754,7 @@ Thus, `<>F` skips those (successfully) matched entries, leaving only one which f
 
 Now, what if in the latter example above (one with `<>F` directive) we want to process *failed* JSON further, say, to display ip only,
 w/o object itself? That is easily achievable - walking of the *failed* path continues past the `<>F` directive:
-```
+```ShellSession
 bash $ <<<$JSN jtc -w'[:]<>f[name]<>F [ip]'
 "1.1.1.100"
 bash $
@@ -770,7 +770,7 @@ RE search lexemes (`R`, `L`, `D`) also auto-populate the namespaces with followi
 - `$0` is auto-generated for an entire RE match,
 - `$1` for a first RE subgroup,
 - `$2` for a second RE subgroup, and so on
-```
+```ShellSession
 bash $ <ab.json jtc -w'<^J(.*)>R:'
 "John"
 "Jane"
@@ -788,7 +788,7 @@ There are also couple reserved namespaces to acquire a current JSON path:
 - `$PATH`: that namespace contains a _JSON array_ describing path to the currently selected element
 - `$path`: this is a stringified representation of the path
 Here are both demonstrated:
-```
+```ShellSession
 bash $ <ab.json jtc -w'<Jane>' -T'{{$PATH}}' -r
 [ "Directory", 2, "name" ]
 bash $ <ab.json jtc -w'<NY>' -T'{{$path}}'
@@ -811,7 +811,7 @@ Quantifiers exist in the following formats:
 matches would be produced, so it's impossible to select a range/slice based off the last match), the rest of the notation rules apply
 
 To illustrate the quantifiers (with suffixes), let's dump all the _JSON arrays_ in the `Directory`, except the top one:
-```
+```ShellSession
 bash $ <ab.json jtc -w'<>i1:' -r
 [ "Olivia" ]
 [ { "number": "112-555-1234", "type": "mobile" }, { "number": "113-123-2368", "type": "mobile" } ]
@@ -831,7 +831,7 @@ Those are
 [non-recursive searches](https://github.com/ldn-softdev/jtc/blob/master/User%20Guide.md#non-recursive-search)
 will uniquely match label or index. Indeed, in a plain _JSON array_ or an _object_ it's possible
 to address only one **single** label or index, there could not be any other, e.g. in this JSON:
-```
+```ShellSession
 bash $ <<<'{ "a": 1, "b":2, "c":3, "d":4, "e":6 }' jtc -r
 { "a": 1, "b": 2, "c": 3, "d": 4, "e": 6 }
 bash $
@@ -842,7 +842,7 @@ make much of a sense: `<<<'{ "a": 1, "b":2, "c":3, "d":4, "e":6 }' jtc -w'>b<l2'
 Thus the semantic of quantifiers only in those searches was altered (to extend use cases) - there, quantifiers provide a
 _relative offset_ meaning from a found label/index. So, for the notation like above: `'>b<l2'`, the label `"b"` will be matched and
 once match found then its second (successive) neighbor value will be selected:
-```
+```ShellSession
 bash $ <<<'{ "a": 1, "b":2, "c":3, "d":4, "e":6 }' jtc -w'>b<l2' -l
 "d": 4
 bash $
@@ -850,7 +850,7 @@ bash $
 Because of change in semantic, those are the only search quantifiers (they also have to be non-recursive spelling: `>..<l`, `>..<t`)
 which allow negative values. Positive quantifiers let selecting next (successive) neighbors, while negative quantifiers let
 selecting preceding neighbors:
-```
+```ShellSession
 bash $ <<<'{ "a": 1, "b":2, "c":3, "d":4, "e":6 }' jtc -w'>b<l-1' -l
 "a": 1
 bash $
@@ -859,7 +859,7 @@ bash $
 #### Last Walk namespace
 Any last walk could be referred (during interpolation) using an auto-generated namespace `$?`. It comes handy when is required
 to build up JSON 'historical' records:
-```
+```ShellSession
 bash $ <<<'["a","b","c"]' jtc -w[:]
 "a"
 "b"
@@ -878,7 +878,7 @@ The use of that variable comes handy when converting JSON to a `csv` format.
 Search lexemes perform a _recursive_ search across the entire JSON tree off the point where it's invoked (i.e., the JSON node
 selected by walking all the prior lexemes). However, sometimes there's a need to limit searching scope only to the specific label.
 Here is the dump of all the _JSON strings_, where symbol `5` is sighted:
-```
+```ShellSession
 bash $ <ab.json jtc -w'<5>R:'
 "599 Lafayette St"
 "112-555-1234"
@@ -888,7 +888,7 @@ bash $
 ```
 Some of the values are `street address`, some are the phone `number`. Say, we want to dump only the phone records. Knowing the label
 of the phone numbers (`"number"`), it's achievable via this notation:
-```
+```ShellSession
 bash $ <ab.json jtc -w'[number]:<5>R:'
 "112-555-1234"
 "358-303-0373"
@@ -902,7 +902,7 @@ Sometimes there's a need to apply a non-recursive search onto collectable JSON n
 immediate children of the node and do not descend recursively. The notation facilitating such search is the same one, but
 angular brackets to be put inside-out, i.e.: `>..<`. To illustrate that: say, we want to find all string values in the 1st `Directory`
 record containing the letter `o`. If we do this using a recursive search, then all following entries will be found:
-```
+```ShellSession
 bash $ <ab.json jtc -w'[Directory][0]<o>R:'
 "New York"
 "John"
@@ -911,7 +911,7 @@ bash $ <ab.json jtc -w'[Directory][0]<o>R:'
 bash $
 ```
 To facilitate our ask (find all such entries within the immediate values of the 1st record only), apply a non-recursive search notation:
-```
+```ShellSession
 bash $ <ab.json jtc -w'[Directory][0]>o<R:'
 "John"
 bash $
@@ -924,7 +924,7 @@ Typically addressing parents would be needed after search lexemes (but can occur
 be addressed using notation `[-n]`. This feature allows building queries that answer quite complex queries.
 
 Let's dump all the names from the `Directory` whose records have a `home` phone entry:
-```
+```ShellSession
 bash $ <ab.json jtc -w'[type]:<home>:[-3][name]'
 "Ivan"
 "Jane"
@@ -933,7 +933,7 @@ bash $
 The magic which happens here (let's break down the walk-path into the lexemes) is revealed:
   1. `[type]:<home>:` - this lexeme instruct to find all (ending quantifier `:`) strings `home` scoped by label `"type"` (`[type]:` -
   attached scope), thus all such phone records values will be selected:
-  ```
+  ```ShellSession
   bash $ <ab.json jtc -w'[type]:<home>:' -r
   "home"
   "home"
@@ -941,7 +941,7 @@ The magic which happens here (let's break down the walk-path into the lexemes) i
   ```
   2. `[-3]` - starting off those found JSON elements a 3rd ancestor will be selected. Let's see a parent selection in a slow-mo,
   one by one:
-  ```
+  ```ShellSession
   bash $ <ab.json jtc -w'[type]:<home>: [-1]' -r
   { "number": "273-923-6483", "type": "home" }
   { "number": "333-638-0238", "type": "home" }
@@ -959,7 +959,7 @@ The magic which happens here (let's break down the walk-path into the lexemes) i
 
 
 Another example: who is the parent of a child `Lila`?
-```
+```ShellSession
 bash $ <ab.json jtc -w'<children>l:<Lila>[-2][name]'
 "Jane"
 bash $
@@ -971,7 +971,7 @@ Explanation:
 
 
 Even more complex query: who of the parents with children, have mobile numbers?
-```
+```ShellSession
 bash $ <ab.json jtc -w'<children>l:[0][-2][type]:<mobile>[-3][name]'
 "John"
 bash $
@@ -988,7 +988,7 @@ us again up to the person's record level
 6. `[name]` - finally select the name
 
 There's another way to address parents - through `[^n]` notation, compare: the following walk-path achieves exactly the same ask:
-```
+```ShellSession
 bash $ <ab.json jtc -w'<children>l:[0][^2][type]:<mobile>[^2][name]' -r
 "John"
 bash $
@@ -1023,7 +1023,7 @@ will be displaying resulted successful walks in an _interleaved_ manner, but fir
 
 #### Sequential walk processing
 option `-n` ensures that all given walk-paths (`-w`) will be processed (and printed) sequentially in the order they given:
-```
+```ShellSession
 bash $ <ab.json jtc -w'<name>l:' -w'<number>l:' -n
 "John"
 "Ivan"
@@ -1051,7 +1051,7 @@ bash $
 
 #### Displaying walks with labels
 if resulted walks have labels in the input JSON (i.e., they were inside _JSON objects_), then `-l` let dumping their labels too:
-```
+```ShellSession
 bash $ <ab.json jtc -w'<name>l:' -w'<number>l:' -nl
 "name": "John"
 "name": "Ivan"
@@ -1070,7 +1070,7 @@ bash $
 `-j` does a quite simple thing - it wraps all walked entries back into a _JSON array_, however predicated by `-l` and `-n` options
 the result will vary:
 - `-j` without `-l` will just arrange walked entries into a JSON array:
-  ```
+  ```ShellSession
   bash $ <ab.json jtc -w'<name>l:' -w'<number>l:' -nj
   [
      "John",
@@ -1086,7 +1086,7 @@ the result will vary:
   bash $
   ```
 - once `-j` and `-l` given together, then entries which have labels (i.e., come from the _JSON objects_) will be wrapped into objects:
-  ```
+  ```ShellSession
   bash $ <ab.json jtc -w'<name>l:' -w'<number>l:' -n -j -l
   [
      {
@@ -1126,7 +1126,7 @@ often it's required to group relevant walks together and then place them into re
 #### Interleaved walk processing
 Interleaved walk processing (and outputting) occurs by default, though there's a certain way to control it. Let's take a look at the
 above outputs dropping the option `-n` (i.e., print walks _interleaved_):
-```
+```ShellSession
 bash $ <ab.json jtc -w'<name>l:' -w'<number>l:'
 "John"
 "112-555-1234"
@@ -1147,7 +1147,7 @@ relevance between themselves.
 Right now both paths (`<name>l:` and `<number>l:`) do not have common base lexemes, thus it's unclear how to relate resulting walks
 (hence they just interleaved one by one). Though if we provide walk-paths relating each of those searches to their own record,
 then magic happens:
-```
+```ShellSession
 bash $ <ab.json jtc -w '[Directory][:] <name>l:' -w'[Directory][:] <number>l:'
 "John"
 "112-555-1234"
@@ -1161,7 +1161,7 @@ bash $ <ab.json jtc -w '[Directory][:] <name>l:' -w'[Directory][:] <number>l:'
 bash $
 ```
 And now, applying options `-j` together with `-l` gives a lot better result:
-```
+```ShellSession
 bash $ <ab.json jtc -w '[Directory][:]<name>l:' -w'[Directory][:] <number>l:' -jl
 [
    {
@@ -1191,7 +1191,7 @@ bash $
 
 #### Aggregating walks
 the walks also could be aggregated (per label), option `-nn` facilitates the ask:
-```
+```ShellSession
 bash $ <ab.json jtc -w '[Directory][:]<name>l:' -w'[Directory][:] <number>l:' -jl -nn
 [
    {
@@ -1219,7 +1219,7 @@ bash $
 which do not have labels (i.e., elements in _JSON array_ and root) will be ignored.
 
 E.g., let's dump all values from `Jane`'s record and wrap them all into an object:
-```
+```ShellSession
 bash $ <ab.json jtc -w'<Jane>[-1]<>a:' -jj
 {
    "age": 25,
@@ -1252,7 +1252,7 @@ This become especially useful when dealing with templates. Let's consider a foll
 
 Say, the ask here is to extract names of all the people from `ab.json` and group them with newly crafted record indicating if a person
 has children or not, like this:
-```
+```json
 [
    {
        "name": "John",
@@ -1263,7 +1263,7 @@ has children or not, like this:
 ```
 
 1\. Extracting names is easy:
-```
+```ShellSession
 bash $ <ab.json jtc -w'[0][:][name]'
 "John"
 "Ivan"
@@ -1276,7 +1276,7 @@ bash $
 and
 [namespace interpolation](https://github.com/ldn-softdev/jtc/blob/master/User%20Guide.md#interpolation)
 , for now let's just construct a walk which create required namespace:
-```
+```ShellSession
 bash $ <ab.json jtc -w'[0][:][name]' -w'[0][:][children] <C:"no">f[0]<C:"yes">v'
 "John"
 "Olivia"
@@ -1297,7 +1297,7 @@ b/c if array `children` were empty, that walk would fail)
 
 3\. by now, each time when second walk finishes iteration, the namespace `C` should be correctly set to the respective values reflecting
 if a person has children or not, but to see that, we'd need to interpolate that namespace using a template:
-```
+```ShellSession
 bash $ <ab.json jtc -w'[0][:][name]' -w'[0][:][children] <C:"no">f[0]<C:"yes">v' -TT -T'{"has children": "{C}"}'
 "John"
 {
@@ -1314,7 +1314,7 @@ bash $ <ab.json jtc -w'[0][:][name]' -w'[0][:][children] <C:"no">f[0]<C:"yes">v'
 bash $
 ```
 4. okay, we're getting closer, but now we want to display all records with labels:
-```
+```ShellSession
 bash $ <ab.json jtc -w'[0][:][name]' -w'[0][:][children] <C:"no">f[0]<C:"yes">v' -TT -T'{"has children": "{C}"}' -l
 "name": "John"
 jtc jnode exception: label_accessed_not_via_iterator
@@ -1324,7 +1324,7 @@ Bummer! The exception (rightfully) occurs here because trying to find an outer l
 `{ "has children": "yes" }` fails - indeed it's a standalone JSON, and root does not have any label attached - hence the exception.
 In the situations like this, we'd rather want to reach out inside the object for the labeled value rather than find an outer label.
 The option `-ll` facilitates that need:
-```
+```ShellSession
 bash $ <ab.json jtc -w'[0][:][name]' -w'[0][:][children] <C:"no">f[0]<C:"yes">v' -TT -T'{"has children": "{C}"}' -llj
 [
    {
@@ -1355,7 +1355,7 @@ If you look at the prior example
 , you may notice that a common part of both walk-paths (`[Directory][:]`) we had to give twice. There's a way to express it in more
 succinct syntax: options `-x` and `-y` allows rearrange walk-paths so that `-x` takes an initial common part of the walk-path,
 whereas `-y` would take care of the individuals trailing pars. Thus the same example cold have been written like this:
-```
+```ShellSession
 bash $ <ab.json jtc -x'[Directory][:]' -y'<name>l:' -y'<number>l:'
 "John"
 "112-555-1234"
@@ -1371,7 +1371,7 @@ bash $
 \- each occurrence of `-x` will be reconciled with all subsequent `-y` (until next `-x` is faced). Options `-x`, `-y` is merely
 a syntactical sugar and do not apply any walk-path parsing or validation, instead they just result in the respective `-w` options
 creations (internally), then the latter get processed. Thus, it's even possible to write it with what it seems a broken syntax at first:
-```
+```ShellSession
 bash $ <ab.json jtc -x'[Directory][:' -y']<name>l:' -y']<number>l:'
 ...
 ```
@@ -1380,7 +1380,7 @@ However, if a reinstatement of the options results in a valid walk-path - that's
 It's possible to combine both syntaxes (i.e., `-w` with `-x` and `-y`), however, given that the processing of `-x` and `-y`
 internally reinstates respective options `-w`, the former will be appended after any of given `-w` options (which will affect the
 order of processing/outputting) even though the order of their appearance is different:
-```
+```ShellSession
 bash $ <ab.json jtc -x'[Directory][:]' -y'<name>l:' -y'<number>l:' -w '<children>l:' -rnl
 "children": [ "Olivia" ]
 "children": []
@@ -1414,7 +1414,7 @@ Both `n` and `N` are generally positive numbers, though there's a special notati
 to be displayed
 
 Say, we want to display _every 4th walk_ of the below JSON:
-```
+```ShellSession
 bash $ <<<'[1,2,3,4,5,6,7,8,9]' jtc -w[:]
 1
 2
@@ -1430,14 +1430,14 @@ bash $
 One way to achieve that would be to use templates (the trick is shown in
 [Multiple templates and walks](https://github.com/ldn-softdev/jtc/blob/master/User%20Guide.md#multiple-templates-and-walks)
 section), but it's quite impractical. Much easier is to use `-x` option here:
-```
+```ShellSession
 bash $ <<<'[1,2,3,4,5,6,7,8,9]' jtc -w[:] -x4
 4
 8
 bash $
  ```
 To display _every 4th walk starting from 3rd one_, use this notation:
-```
+```ShellSession
 bash $ <<<'[1,2,3,4,5,6,7,8,9]' jtc -w[:] -x4/2
 3
 7
@@ -1445,7 +1445,7 @@ bash $
 ```
 \- reminder: the second number in the option is an index and thus is zero based.
 Lets add to the output the very first walk and the last one:
-```
+```ShellSession
 bash $ <<<'[1,2,3,4,5,6,7,8,9]' jtc -w[:] -x4/2 -x/0 -x/-1
 1
 3
@@ -1476,7 +1476,7 @@ different flavors, one of them is the `walk-path` per-se.
 ### In-place JSON modification
 By default `jtc` will expect input from `stdin`. If the standalone argument `json_file` is given, then `jtc` will read
 input from the file (ignoring `stdin`), see below:
-```
+```ShellSession
 bash $ cat file.json
 [
    "JSON",
@@ -1500,7 +1500,7 @@ bash $
 ```
 If option `-f` is given (together with a _single_ `json_file` argument) then `jtc` will apply (redirect) its output of the operations
 into the file (instead of `stdout`):
-```
+```ShellSession
 bash $ <<<'[ "<stdin>", "JSON" ]' jtc -f file.json
 bash $ cat file.json
 [
@@ -1513,7 +1513,7 @@ bash $
 In the above example, JSON is read from `file.json` and output back into the file (`stdin` input is ignored).
 
 The bare hyphen (`-`) overrides a file input and ensured that the input is read from the `stdin`:
-```
+```ShellSession
 bash $ <<<'[ "input", "JSON" ]' jtc -f - file.json
 bash $ cat file.json
 [
@@ -1527,7 +1527,7 @@ bash $
 ### Purging JSON
 `-p` removes from JSON all walked elements (given by one or multiple `-w`). E.g.: let's remove from address book (for the sake
 of example) all the `home` and `office` phones records (effectively leaving only `mobile` types):
-```
+```ShellSession
 bash $ <<<$(<ab.json jtc -w'[type]:<home>:[-1]' -w'[type]:<office>:[-1]' -p) jtc -w'<phone>l:' -l
 "phone": [
    {
@@ -1549,18 +1549,18 @@ bash $ <<<$(<ab.json jtc -w'[type]:<home>:[-1]' -w'[type]:<office>:[-1]' -p) jtc
 bash $
 ```
 Of course there's a more succinct syntax:
-```
+```ShellSession
 bash $ <ab.json jtc -x[type]: -y'<home>:[-1]' -y'<office>:[-1]' -p
 ```
 or, using even a single walk-path:
-```
+```ShellSession
 bash $ <ab.json jtc -w'[type]:<(?:home)|(?:office)>R: [-1]' -p
 ```
 
 
 Another use-case exist: remove all the JSON elements _except_ walked ones (while preserving original JSON structure) - that's
 the feat for plural option notation: `-pp`. Let's drop all entries (in all records) but the `name` and `spouse`:
-```
+```ShellSession
 bash $ <ab.json jtc -w'<(?:name)|(?:spouse)>L:' -pp
 {
    "Directory": [
@@ -1589,7 +1589,7 @@ Here, `(?:name)|(?:spouse)` is an RE (indicated by capitalized label search suff
 and resulted JSON elements will be swapped around.
 
 E.g., here's an example of swapping around `name` and `spouse` for all records on the address book:
-```
+```ShellSession
 bash $ <<<$(<ab.json jtc -w'<name>l:' -w'<spouse>l:' -s) jtc -w'<(?:name)|(?:spouse)>L:' -l
 "name": "Martha"
 "spouse": "John"
@@ -1604,7 +1604,7 @@ _\- for the sake of example brevity, swapped elements only sorted out_
 
 Possibly, a more frequent use-case for `-s` is when it's required to remove some extra/redundant nestedness in a JSON structure.
 For the sake of example, let's remove _array_ encapsulation from phone records, leaving only the last phone in it:
-```
+```ShellSession
 bash $ <<<$(<ab.json jtc -w'<phone>l:' -w'<phone>l:[-1:]' -s) jtc -w'<phone>l:' -l
 "phone": {
    "number": "113-123-2368",
@@ -1666,7 +1666,7 @@ Alternatively, add a trailing space at the end of the walk-lexeme: `[0] ` - then
 The destination insertion point(s) (`-w`) controls how insertion is done:
 - if a given destination insertion point (`-w`) is a single walk and non-iterable - i.e., if it's a single point location - then
 all the supplied sources are attempted to get inserted into a single destination location:
-```
+```ShellSession
 bash $ <ab.json jtc -w'<children>l:' -lr
 "children": [ "Olivia" ]
 "children": []
@@ -1681,7 +1681,7 @@ bash $
 - if a given destination insertion point is iterable or multiple are given, then all sources (`-i` arguments) are inserted one
 by one in a circular fashion (if source runs out of JSON elements, but destination has more room to iterate, then source
 is wrapped to the beginning element):
-```
+```ShellSession
 bash $ <<<$(<ab.json jtc -w'<children>l:' -i'"Maggie"' -i'"Bruce"') jtc -w'<children>l:' -lr
 "children": [ "Olivia", "Maggie" ]
 "children": [ "Bruce" ]
@@ -1695,7 +1695,7 @@ while insertion into arrays is obvious (well, so far), insertion into object req
 - in case of clashing labels - destination is preserved while source is discarded
 
 To illustrate: let's insert a JSON structure: `{ "PO box": null, "street address": null }` into the last record's `address`:
-```
+```ShellSession
 bash $ <ab.json jtc -w'[0][-1:][address]' -l
 "address": {
    "city": "Denver",
@@ -1799,7 +1799,7 @@ using update operation (insert into labels is not possible even semantically). H
 last lexeme in the walk-path (or the last lexeme before `><F`) and if it's empty.
 
 As the an exercise, let's capitalize all the labels within all `address`'es in `ab.json`:
-```
+```ShellSession
 bash $ <<<$(<ab.json jtc -w'<address>l:[:]<>k' -eu '<<<{{}}' tr '[:lower:]' '[:upper:]' \;) jtc -w'<address>l:' -rl
 "address": { "CITY": "New York", "POSTAL CODE": 10012, "STATE": "NY", "STREET ADDRESS": "599 Lafayette St" }
 "address": { "CITY": "Seattle", "POSTAL CODE": 98104, "STATE": "WA", "STREET ADDRESS": "5423 Madison St" }
@@ -1809,7 +1809,7 @@ bash $
 
 NOTE: _mind the caveat - destination walk-path may become invalid (namely, when altering labels of the nested elements after
 the parent's label has been altered), in such case the update operation won't be applied due to invalidated destination_:
-```
+```ShellSession
 bash $ <ab.json jtc -x[Directory][0][address] -y'<>k' -y'[:]<>k'
 "address"
 "city"
@@ -1850,7 +1850,7 @@ bash $
 ```
 
 to achieve what's intended, first the most inner labels have to be walked/processed and then the outers:
-```
+```ShellSession
 bash $ <<<$(<ab.json jtc -x[Directory][0][address] -y'[:]<>k' -y'<>k' -eu '<<<{{}}' tr '[:lower:]' '[:upper:]' \;) jtc -w'[Directory][0]'
 {
    "ADDRESS": {
@@ -1881,7 +1881,7 @@ bash $
 
 **The above caveat is applicable only when label is being updated using _cli evaluation_.**
 When labels updated without _cli evaluation_ then recursive update is not a problem:
-```
+```ShellSession
 bash $ <<<$(<ab.json jtc -x[Directory][0][address] -y'<L>k<>k' -y'[:]<L>k<>k' -u0 -T'"NEW-{L}"') jtc -w'[Directory][0]'
 {
    "NEW-address": {
@@ -1921,7 +1921,7 @@ the operation, the source elements (referred by the source walk-path) become pos
 This is achievable by specifying option `-p`.
 
 Let's move `address` from the last `Directory` record into the first one:
-```
+```ShellSession
 bash $ <ab.json jtc -w'[Directory][0][address]' -u'[Directory][-1:][address]' -p
 {
    "Directory": [
@@ -2000,7 +2000,7 @@ bash $
 ### Insert, Update: argument shell evaluation
 An argument for _insert_ and _update_ operations (`-i`, `-u`) optionally may undergo a shell evaluation (predicated by preceding `-e`).
 E.g., let's capitalize all the `name` entries in the address book:
-```
+```ShellSession
 bash $ <ab.json jtc -w'<name>l:'
 "John"
 "Ivan"
@@ -2026,7 +2026,7 @@ promoted to a _JSON string_ value)
 
 if shell cli does not deliver expected result for some reason, it's easy to see why with `-dd` option, e.g, say, we want to
 truncate all kid's names to 3 letters only (just for fun):
-```
+```ShellSession
 bash $ <<<$(<ab.json jtc -w'<children>l:[:]' -j) jtc -w[:] -eu <<<{} sed -E 's/(...).*/\1/' \; -dd
 .read_inputs(), reading json from <stdin>
 ..demux_opt(), option: '-u', hits: 3
@@ -2044,7 +2044,7 @@ bash $
 ```
 \- It did not work, because `jtc` received at the input only just this `{}`. Obviously `<<<{}` was interpolated by shell -
 `jtc` got that, thus, we have to quote it:
-```
+```ShellSession
 bash $ <ab.jsonbash $ <<<$(<ab.json jtc -w'<children>l:[:]' -j) jtc -w[:] -eu '<<<{}' sed -E 's/(...).*/\1/' \; -dd
 .read_inputs(), reading json from <stdin>
 ..demux_opt(), option: '-u', hits: 4
@@ -2085,7 +2085,7 @@ bash $
 \- Now it did not work, because `jtc` received `sed`'s argument without single quotations (again those have been eaten by bash
 before passing to `jtc` -  something `jtc` is unable to control - shell arguments evaluation of its own arguments). Thus,
 let's double quote it now:
-```
+```ShellSession
 bash $ <<<$(<ab.json jtc -w'<children>l:[:]' -j) jtc -w[:] -eu '<<<{}' sed -E "'s/(...).*/\1/'" \; -dd
 .read_inputs(), reading json from <stdin>
 ..demux_opt(), option: '-u', hits: 4
@@ -2132,7 +2132,7 @@ bash $
 Now it worked!
 
 Actually, the whole _cli_ could have been coded like this:
-```
+```ShellSession
 bash $ <<<$(<ab.json jtc -w'<children>l:[:]' -j) jtc -w[:] -eu '<<<{} sed -E "s/(...).*/\1/";'
 [
    "Oli",
@@ -2144,7 +2144,7 @@ bash $
 Of course, the above way of solving the ask is entirely academic - it's always best to avoid using _shell cli_ evaluation and
 default to it only as a last resort.
 A much better (efficient) way achieving the same ask would be to use RE and template interpolation:
-```
+```ShellSession
 bash $ <<<$(<ab.json jtc -w'<children>l:[:]' -j) jtc -w'<(...)>R:' -T'"{$1}"' -j
 [
    "Oli",
@@ -2161,7 +2161,7 @@ options `-c`, `-u`, `-i` allow two *kinds* of their arguments:
 2. walk-path (i.e., `<walk-path>`)
 
 \- when those used together, namely a `<walk-path>` argument(s) follows either of statics, e.g.:
-```
+```ShellSession
 jtc -u file.json -u'[Root][:]'`
 ```
 then all `<walk-path>` arguments (here `[Root][:]`) apply onto the static argument (here `file.json`).
@@ -2195,7 +2195,7 @@ a destination
 Hopefully this example will clarify:
 - say (just for the sake of example), we want to add to every record's `children` the `name` of the person, but not just - we
 want to add it in all capitals (i.e., transform the record).
-```
+```ShellSession
 bash $ <<<$(<ab.json jtc -ei '<<<{{}}' tr '[:lower:]' '[:upper:]' \; -i'<name>l:' -w'<children>l:') jtc -lrw'<name>l:' -w'<children>l:'
 "name": "John"
 "children": [ "Olivia", "JOHN" ]
@@ -2243,7 +2243,7 @@ examples) - root is always assumed_
 ## Comparing JSONs
 `-c` allows comparing JSONs (or JSONs element pointed by walk-paths) - `jtc` will display JSON delta (diffs) between compared JSONs.
 Let's compare `phone` records from the first and  the second entries of the address book:
-```
+```ShellSession
 bash $ <ab.json jtc -w'[Directory][0][phone]' -c'[Directory][1][phone]' -l
 "json_1": [
    {
@@ -2266,7 +2266,7 @@ bash $ <ab.json jtc -w'[Directory][0][phone]' -c'[Directory][1][phone]' -l
 bash $
 ```
 When both JSONs are equal, an empty set is displayed and return code is 0.
-```
+```ShellSession
 bash $ <<<'123' jtc -c'123' -l
 "json_1": {}
 "json_2": {}
@@ -2275,7 +2275,7 @@ bash $ echo $?
 bash $
 ```
 Otherwise (JSONs are different) a non-zero code is returned:
-```
+```ShellSession
 bash $ <<<'[1,2,3]' jtc -c'[2,3]' -lr
 "json_1": [ 1, 2, 3 ]
 "json_2": [ 2, 3 ]
@@ -2292,7 +2292,7 @@ different contents (leaf data), while their structures could be the same (though
 validate types of the leaf data as well).
 
 E.g., if we add/insert a child into `Ivan`'s record, then the record would be different from the original:
-```
+```ShellSession
 bash $ <<<$(<ab.json jtc -w'<Ivan>[-1] [children]' -i'"Norma"') jtc -w'<Ivan>[-1]' -c'ab.json' -c'<Ivan>[-1]' -l
 "json_1": {
    "children": [
@@ -2305,7 +2305,7 @@ bash $
 
 However, their schemas would be the same. To compare schemas of two JSONs (loosely, with applied exemption on checking leaves data types),
 label directive `<>k` used together with `<>c` search suffix come handy:
-```
+```ShellSession
 bash $ <<<$(<ab.json jtc -w'<Ivan>[-1] [children]' -i'"Norma"') jtc -w'<Ivan>[-1]<>c:<>k' -c'ab.json' -c'<Ivan>[-1]<>c:<>k' -l
 "json_1": {}
 "json_2": {}
@@ -2326,7 +2326,7 @@ bash $
 
 NOTE: _usage of '<>k' is only restricted to JSON elements which have labels/indices. JSON `root` does not have any of those, thus
 attempting to print a label of the root always results in the exception:_
-```
+```ShellSession
 bash $ <ab.json jtc -w'<>k'
 jtc json exception: walk_root_has_no_label
 bash $
@@ -2363,7 +2363,7 @@ The difference between single `{}` and double `{{}}` notations:
 
 
 A string interpolation w/o outer quotes is handy when it's required altering an existing string, here's example of altering JSON label:
-```
+```ShellSession
 bash $ <<<'{ "label": "value" }' jtc
 {
    "label": "value"
@@ -2375,7 +2375,7 @@ bash $ <<<'{ "label": "value" }' jtc -w'<label>l<>k' -u'<label>l<L>k' -T'"new {L
 bash $
 ```
 Here's an illustration when double braces are handier (e.g., swapping around labels and values):
-```
+```ShellSession
 bash $ JSN='{ "pi": 3.14, "type": "irrational" }'
 bash $ <<<$JSN jtc
 {
@@ -2393,7 +2393,7 @@ bash $
 An array interpolation using a single brace notation `{..}` is handy when there's a need extending the array _during_
 interpolation.
 There's a special case though - template-extending of an empty array. Let's consider a following example:
-```
+```ShellSession
 bash $ JSN='[ {"args": [123],"Func": "x + y"}, { "args":[], "Func":"a * b" }  ]'
 bash $ <<<$JSN jtc
 [
@@ -2411,7 +2411,7 @@ bash $ <<<$JSN jtc
 bash $
 ```
 And the ask here would be to augment all arrays in each `args` with the arguments from respective `Func`:
-```
+```ShellSession
 bash $ <<<$JSN jtc -w'[:][args]' -u'[:][Func]<(\w+)[ +*]+(\w+)>R[-1][args]' -T'[{}, {{$1}}, {{$2}}]'
 [
    {
@@ -2445,7 +2445,7 @@ of enumerations occurring over of either of `,` or `;`
 ### Namespaces with interleaved walks
 When multiple _interleaved_ walks (`-w`) present (obviously there must be multiple walks - a single one cannot be _interleaved_),
 they populate namespaces in the order the walks appear:
-```
+```ShellSession
 bash $ <ab.json jtc -x[0][:] -y'[name]<pnt>v' -y'[children][:]<chld>v' -T'{ "Parent": {{pnt}}, "child": {{chld}} }' -r
 "John"
 { "Parent": "John", "child": "Olivia" }
@@ -2471,7 +2471,7 @@ each own child. That way, for example, `Ivan` should not be even listed (he has 
 once and `Jane` should have 2 records (she has 2 kids).
 
 The situation could be easily rectified if for each walk we use own template and assign a dummy one for the first one:
-```
+```ShellSession
 bash $ <ab.json jtc -x[0][:] -y'[name]<pnt>v' -T'""' -y'[children][:]<chld>v' -T'{ "Parent": {{pnt}}, "child": {{chld}} }' -r
 ""
 { "Parent": "John", "child": "Olivia" }
@@ -2483,7 +2483,7 @@ bash $
 ```
 Now the result looks closer to the intended one (no records for `Ivan`, one for `John` and 2 for `Jane`, as expected). But what about
 those annoying empty _JSON strings_ `""`? Those will be gone if `-qq` option is thrown in:
-```
+```ShellSession
 bash $ <ab.json jtc -x[0][:] -y'[name]<pnt>v' -T'""' -y'[children][:]<chld>v' -T'{ "Parent": {{pnt}}, "child": {{chld}} }' -rqq
 { "Parent": "John", "child": "Olivia" }
 { "Parent": "Jane", "child": "Robert" }
@@ -2493,7 +2493,7 @@ bash $
 \- that's a neat, though a [documented](https://github.com/ldn-softdev/jtc/blob/master/User%20Guide.md#unquoting-JSON-strings) trick
 
 Yet, the same could have been achieved even a simpler way (using just one walk):
-```
+```ShellSession
 bash $ <ab.json jtc -w'[0][:][name]<pnt>v[-1][children][:]' -T'{ "Parent": {{pnt}}, "child": {{}} }' -r
 { "Parent": "John", "child": "Olivia" }
 { "Parent": "Jane", "child": "Robert" }
@@ -2505,7 +2505,7 @@ bash $
 ### Search quantifiers interpolation
 Interpolation may also occur in quantifiers, say we have a following JSON, where we need to select an item from `list` by the
 index value stored `item`:
-```
+```ShellSession
 bash $ JSN='{ "item": 2, "list": { "milk": 0.90, "bread": 1.20, "cheese": 2.90 } }'
 bash $ <<<$JSN jtc
 {
@@ -2519,7 +2519,7 @@ bash $ <<<$JSN jtc
 bash $
 ```
 To achieve that, we need to memorize the value of index in the namespace first, then select a value from the list by the index:
-```
+```ShellSession
 bash $ <<<$JSN jtc -w'[item]<idx>v[-1][list]><a{idx}' -l
 "milk": 0.90
 bash $
@@ -2527,20 +2527,20 @@ bash $
 It should be quite easy to read/understand such walk path (predicated one is familiar with suffixes / directives). Let's see
 how the walk-path works in a slow-mo:
 1. `[item]` selects the value by label `item`:
-```
+```ShellSession
 bash $ <<<$JSN jtc -w'[item]'
 2
 bash $
 ```
 2. `<idx>v` the directive memorizes selected value (`2`) in the namespace `idx`
-```
+```ShellSession
 bash $ <<<$JSN jtc -w'[item]<idx>v'
 2
 bash $
 ```
 3. `[-1]` steps up 1 level in the JSON tree off the current position (i.e., addresses the first parent of the `item` value) which is
 the root of the input JSON:
-```
+```ShellSession
 bash $ <<<$JSN jtc -w'[item]<idx>v[-1]'
 {
    "item": 2,
@@ -2553,7 +2553,7 @@ bash $ <<<$JSN jtc -w'[item]<idx>v[-1]'
 bash $
 ```
 4. `[list]` selects the object value by label `list`:
-```
+```ShellSession
 bash $ <<<$JSN jtc -w'[item]<idx>v[-1][list]'
 {
    "bread": 1.20,
@@ -2566,7 +2566,7 @@ bash $
 (which is `2`) gives us the required value.
 
 _Alternatively_, the same ask could be achieved using a slightly different query:
-```
+```ShellSession
 bash $ <<<$JSN jtc -w'[item]<idx>v[-1][list]>idx<t' -l
 "milk": 0.90
 bash $
@@ -2588,7 +2588,7 @@ types of operations) but one requires a reference from another.
 
 Say, we have 2 JSONs:
 1. `main.json`:
-```
+```ShellSession
 bash $ <main.json jtc
 [
    {
@@ -2610,7 +2610,7 @@ bash $ <main.json jtc
 bash $
 ```
 2. `id.json`:
-```
+```ShellSession
 bash $ <id.json jtc
 [
    {
@@ -2636,7 +2636,7 @@ The way to do it:
 
 The insert operation (`-i`) here would need to find `id` record in `id.json` using memorized (in the destination walk) namespace and
 insert respective `title`:
-```
+```ShellSession
 bash $ <main.json jtc -w'[:][rec]<Record>v[-1][songs]' -mi id.json -i'[id]:<Record>s[-1][title]'
 [
    {
@@ -2679,7 +2679,7 @@ The trick is to use a dummy `-u`/`-i` operation and apply `-p`.
 When the cli is given in this notation:
 `<<<dst.json jtc -w... -u <src.json> -u... -p`,
 purging will be applied to walked destinations, but only predicated by a successful source walk:
-```
+```ShellSession
 bash $ <main.json jtc -w'[:][rec]<Record>v[-1]' -u'[{"id":1}, {"id":3}]' -u'[id]:<Record>s' -p
 [
    {
@@ -2692,7 +2692,7 @@ bash $
 ```
 
 The "complemented" purge operation (i.e. when you want to delete everything except referenced) is facilitated using `-pp`:
-```
+```ShellSession
 bash $ <main.json jtc -w'[rec]:<Record>N:[-1]<Entry>v' -u'[1, 3]' -u'<Record>s' -T'{{Entry}}' -pp
 [
    {
@@ -2721,7 +2721,7 @@ then it's a template value (after interpolation) will be used for the operations
 invalid JSON, in such case the source walk will be used).
 
 When walking only is in process, then template interpolation occurs from the walk-path (`-w`):
-```
+```ShellSession
 bash $ <ab.json jtc -w'[0][0]<number>l:'
 "112-555-1234"
 "113-123-2368"
@@ -2742,7 +2742,7 @@ successful
 
 Below is an example of updating the phone records for the first entry in the `Directory` (appending a country-code and
 altering the `phone` label at the same time via template):
-```
+```ShellSession
 bash $ <ab.json jtc -w'[0][0]<phone>l'
 [
    {
@@ -2784,7 +2784,7 @@ In the case when round-robin behavior is required when number of templates and w
 round-robin templates application onto sequential walks
 
 Compare:
-```
+```ShellSession
 bash $ <ab.json jtc -x[0][:] -y[name] -T'{"Person":{{}}}' -y[age] -T'{"Age":{{}}}' -r
 { "Person": "John" }
 { "Age": 25 }
@@ -2814,7 +2814,7 @@ The mess in the above's last example is explained by `-nn` usage: templates are 
 
 
 One handy use-case of multiple round-robin templates would be this example:
-```
+```ShellSession
 bash $ <<<'[1,2,3,4,5,6,7,8,9,10]' jtc -w[:] -T'""' -T{} -T'""' -qq
 2
 5
@@ -2835,7 +2835,7 @@ in a "naked" JSON value (i.e. without quotation marks, curly braces or square br
 respectively). While double token notation is always a safe type and result of operation while be a complete JSON type.
 
 This little demo illustrates the tokens usage:
-```
+```ShellSession
 bash $ <<<'["a", "b"]' jtc -T'">{{}}<"'
 "[ \"a\", \"b\" ]"
 ```
@@ -2843,7 +2843,7 @@ bash $ <<<'["a", "b"]' jtc -T'">{{}}<"'
 The same could have been achieved with the template: `-T'>>{{}}<<'`
 
 That was an example of _stringification_ of a JSON value, now let's do a reverse thing - _jsonize_ previously stringified value:
-```
+```ShellSession
 bash $ <<<'["a", "b"]' jtc -T'>>{{}}<<' | jtc -T'[ <{{}}>, "c"]' -r
 [ "a", "b", "c" ]
 bash $
@@ -2854,7 +2854,7 @@ bash $
 ## Processing multiple input JSONs
 Normally `jtc` would process only a single input JSON. If multiple input JSONs given - the fist JSON will be processed and the
 rest of the inputs will be silently ignored:
-```
+```ShellSession
 bash $ <<<'[ "1st json" ] { "2nd": "json" } "3rd json"' jtc -r
 [ "1st json" ]
 bash $
@@ -2864,7 +2864,7 @@ Couple options allow altering the behavior and process all the input JSONs:
 
 ### Process all input JSONs
 Option `-a` instructs to process all the input JSONS:
-```
+```ShellSession
 bash $ <<<'[ "1st json" ] { "2nd": "json" } "3rd json"' jtc -ar
 [ "1st json" ]
 { "2nd": "json" }
@@ -2872,7 +2872,7 @@ bash $ <<<'[ "1st json" ] { "2nd": "json" } "3rd json"' jtc -ar
 bash $
 ```
 \- respected processing (of all given options) will occur for all of the input JSONs:
-```
+```ShellSession
 bash $ <<<'[ "1st json" ] { "2nd": "json" } "3rd json"' jtc -a -w'<json>R'
 "1st json"
 "json"
@@ -2881,7 +2881,7 @@ notice: input atomic JSON is non-iterable, ignoring all walk-paths (-w)
 bash $
 ```
 All the input JSONs will be processed as long they are valid - processing will stops upon parsing failure:
-```
+```ShellSession
 bash $ <<<'[ "1st json" ] { "2nd": json" } "3rd json"' jtc -ad
 .read_inputs(), reading json from <stdin>
 .write_json(), outputting json to <stdout>
@@ -2896,7 +2896,7 @@ bash $
 
 ### Wrap all processed JSONs
 option `-J` let wrapping all processed input JSONs into a super JSON array (option `-J` assumes option `-a`, no need giving both):
-```
+```ShellSession
 bash $ <<<'[ "1st json" ] { "2nd": "json" } "3rd json"' jtc -J -w'<json>R'
 notice: option -J cancels streaming input
 notice: input atomic JSON is non-iterable, ignoring all walk-paths (-w)
@@ -2909,7 +2909,7 @@ bash $
 ```
 option `-J` also implicitly imposes `-j` thus it could be used safely even with a single JSON at the input with the same effect.
 Though, when walking multiple input JSONs, each of the option would have its own effect, this example clarifies:
-```
+```ShellSession
 bash $ jtc -w'[0][:][name]' -aj ab.json ab.json
 [
    "John",
@@ -2972,7 +2972,7 @@ a network-based streaming)
 
 We can see the difference in the parsing when debugging `jtc`:
 \- in a _buffered read_ mode, the debug will show the _parsing point_ with data after:
-```
+```ShellSession
 bash $ <ab.json jtc -dddddd
 .read_inputs(), reading json from <stdin>
 ......parse_(), parsing point ->{|  "Directory": [|    {|       "name": "John",|       "ag...
@@ -2982,7 +2982,7 @@ bash $ <ab.json jtc -dddddd
 ...
 ```
 \- in a _streamed read_ mode, the _parsing point_ would point to the last read character from the `<stdin>`:
-```
+```ShellSession
 bash $ <ab.json jtc -dddddd -a
 .read_inputs(), reading json from <stdin>
 ..ss_init_(), initializing: stream
@@ -3037,7 +3037,7 @@ Say, we want to dump into `csv` format following data from the `ab.json`:
 `name, city, postal code, state, street address`
 
 1. First let's just dump all those entries:
-```
+```ShellSession
 bash $ <ab.json jtc -rx[0][:] -y[name] -y[address][:]
 "John"
 "New York"
@@ -3059,7 +3059,7 @@ bash $
 \- not that difficult
 
 2. then we need to reconcile all the walks into lines, here `$?` auto-namespace comes handy:
-```
+```ShellSession
 bash $ <ab.json jtc -rx[0][:] -y[name] -y[address][:] -T'"{$?}, {}"'
 "John"
 "John, New York"
@@ -3082,7 +3082,7 @@ bash $
 
 3. To ensure that we reconcile only each record (and not all of them), let's add one more walk which will fail interpolation of `$?`
 in the template (that will reset the value of `$?` back to `""`)
-```
+```ShellSession
 bash $ <ab.json jtc -rx[0][:] -y[name] -y[address][:] -y' ' -T'"{$?}, {}"'
 "John"
 "John, New York"
@@ -3107,7 +3107,7 @@ bash $
 \- that's better, now every 5th walk out of every 6 is what we need.
 
 4. Display only required walks:
-```
+```ShellSession
 bash $ <ab.json jtc -rx[0][:] -y[name] -y[address][:] -y' ' -T'"{$?}, {}"' -x6/4
 "John, New York, 10012, NY, 599 Lafayette St"
 "Ivan, Seattle, 98104, WA, 5423 Madison St"
@@ -3117,7 +3117,7 @@ bash $
 \- that is our required `CSV` format! Well, almost - every line is still a JSON string, but we can undress it with `-qq` option
 
 5. just a sugar topping: let's add a header line, which could be done using `echo` unix cli:
-```
+```ShellSession
 bash $ echo -e "name, city, postal, street\n$(<ab.json jtc -x[0][:] -y[name] -y'[address][:]' -y' ' -T'"{$?}, {}"' -x6/4 -qq)"
 name, city, postal, street
 John, New York, 10012, NY, 599 Lafayette St
@@ -3130,7 +3130,7 @@ DONE.
 
 ### Taming duplicates
 Quite very common tasks (and requests) for JSON is to process duplicates. Say, we deal with the following JSON:
-```
+```ShellSession
 bash $ dups='[ "string", true, null, 3.14, "string", null ]'
 bash $ <<<$dups jtc
 [
@@ -3145,7 +3145,7 @@ bash $
 ```
 So, let's
 #### Remove duplicates
-```
+```ShellSession
 bash $ <<<$dups jtc -w'<>Q:' -p
 [
    "string",
@@ -3160,7 +3160,7 @@ elements
 
 But there's a reverse action:
 #### Remove all but duplicates
-```
+```ShellSession
 bash $ <<<$dups jtc -w'<>Q:' -pp
 [
    "string",
@@ -3172,7 +3172,7 @@ That one is obvious - we just reversed the prior example.
 
 How about:
 #### Leave only those which have no duplicates
-```
+```ShellSession
 bash $ <<<$dups jtc -w'<dup>Q:[^0]<dup>s:' -p
 [
    true,
@@ -3188,7 +3188,7 @@ that way all duplicates (and their origins) will be removed, leaving the array o
 
 and finally
 #### Leave all duplicates
-```
+```ShellSession
 bash $ <<<$dups jtc -w'<dup>Q:[^0]<dup>s:' -pp
 [
    "string",
@@ -3207,14 +3207,14 @@ Thus use them cautiously when dealing with big JSONs (around or above hundreds o
 
 ### Counting with `jtc`
 Counting any number of properties is JSON could be done using exteral `wc` unix utility. E.g., let's count all `number`s in `ab.json`:
-```
+```ShellSession
 bash $ <ab.json jtc -w'<number>l:' | wc -l
        6
 bash $
 ```
 
 The same is possible to achieve using only `jtc` capability - using `<..>I` lexeme:
-```
+```ShellSession
 bash $ <ab.json jtc -w'<number>l:<cnt>I1' -T{cnt} -x/-1
 6
 bash $
@@ -3224,7 +3224,7 @@ bash $
 - `-x/-1` will display on the last walk
 
 Say, now we want to count the same phone numbers, but for some reason starting from `100`:
-```
+```ShellSession
 bash $ <ab.json jtc -w'<cnt:100>f[]<>F<number>l:<cnt>I1' -T{cnt} -x/-1
 106
 bash $
@@ -3235,7 +3235,7 @@ continue walking past `<>F` lexeme - that will ensure that initial offset of the
 
 
 Finally, let's count home numbers and mobile numbers separately:
-```
+```ShellSession
 bash $ <ab.json jtc -x'<phone>l:' -y'<home>:<hn>I1'  -y'<mobile>:<mn>I1' -T'{"total home numbers": {hn}, "total mobile numbers": {mn}}' -x/-1
 {
    "total home numbers": 2,

--- a/User Guide.md
+++ b/User Guide.md
@@ -1549,18 +1549,18 @@ bash $ <<<$(<ab.json jtc -w'[type]:<home>:[-1]' -w'[type]:<office>:[-1]' -p) jtc
 bash $
 ```
 Of course there's a more succinct syntax:
-````
+```
 bash $ <ab.json jtc -x[type]: -y'<home>:[-1]' -y'<office>:[-1]' -p
-````
+```
 or, using even a single walk-path:
-````
+```
 bash $ <ab.json jtc -w'[type]:<(?:home)|(?:office)>R: [-1]' -p
-````
+```
 
 
 Another use-case exist: remove all the JSON elements _except_ walked ones (while preserving original JSON structure) - that's
 the feat for plural option notation: `-pp`. Let's drop all entries (in all records) but the `name` and `spouse`:
-````
+```
 bash $ <ab.json jtc -w'<(?:name)|(?:spouse)>L:' -pp
 {
    "Directory": [
@@ -1579,7 +1579,7 @@ bash $ <ab.json jtc -w'<(?:name)|(?:spouse)>L:' -pp
    ]
 }
 bash $
-````
+```
 Here, `(?:name)|(?:spouse)` is an RE (indicated by capitalized label search suffix `L`) matching labels containing either `"name"` or
 `"spouse"`
 

--- a/Walk-path tutorial.md
+++ b/Walk-path tutorial.md
@@ -73,7 +73,7 @@ let's start with the most common one - _numerical offset_
 (walked) JSON, staring from `0` (indices are always zero-based):
 
 Let's work with this JSON:
-```bash
+```ShellSession
 bash $ JSN='["abc", false, null, { "pi": 3.14}, [ 1,"two", {"number three": 3}] ]'
 bash $ <<<$JSN jtc
 ```
@@ -96,7 +96,7 @@ bash $ <<<$JSN jtc
 ```
 
 - select _1st_ element in _JSON array_:
-```bash
+```ShellSession
 bash $ <<<$JSN jtc -w[0]
 ```
 ```json
@@ -104,7 +104,7 @@ bash $ <<<$JSN jtc -w[0]
 ```
 
 \- select _5th_ element in _JSON array_:
-```bash
+```ShellSession
 bash $ <<<$JSN jtc -w[4]
 ```
 ```json
@@ -121,7 +121,7 @@ If the selected element is non-atomic (a.k.a. _iterable_), i.e., _Json array_, o
 further the selected (walked) JSON tree:
 
 \- select _5th_ element in _JSON array_ and then _3rd_ one:
-```bash
+```ShellSession
 bash $ <<<$JSN jtc -w[4][2]
 ```
 ```json
@@ -132,7 +132,7 @@ bash $ <<<$JSN jtc -w[4][2]
 
 If we try selecting a 2nd element from the resulted JSON (which has only single element), walking will fail and the output
 will be blank:
-```bash
+```ShellSession
 bash $ <<<$JSN jtc -w[4][2][1]
 bash $
 bash $ <<<$JSN jtc -w[4][2][0]
@@ -152,7 +152,7 @@ E.g.: `[ 0 ]` will address an element with the label `" 0 "`.
 
 There are two elements in the above JSON that are addressable with _literal subscripts_, let's get to them using _literal subscripts_.
 First, let's get to `pi`'s value:
-```bash
+```ShellSession
 bash $ <<<$JSN jtc -w[3]
 ```
 ```json
@@ -160,7 +160,7 @@ bash $ <<<$JSN jtc -w[3]
    "pi": 3.14
 }
 ```
-```bash
+```ShellSession
 bash $ <<<$JSN jtc -w[3][pi]
 ```
 ```json
@@ -168,7 +168,7 @@ bash $ <<<$JSN jtc -w[3][pi]
 ```
 
 Now let's get to the `number three`'s value:
-```bash
+```ShellSession
 bash $ <<<$JSN jtc -w[4]
 ```
 ```json
@@ -180,7 +180,7 @@ bash $ <<<$JSN jtc -w[4]
    }
 ]
 ```
-```bash
+```ShellSession
 bash $ <<<$JSN jtc -w[4][2]
 ```
 ```json
@@ -188,7 +188,7 @@ bash $ <<<$JSN jtc -w[4][2]
    "number three": 3
 }
 ```
-```bash
+```ShellSession
 bash $ <<<$JSN jtc -w[4][2][number three]
 jtc json exception: unexpected_end_of_string
 ```
@@ -201,7 +201,7 @@ in fact, `jtc` there complains due to a different reason: a second part of a wal
 which `jtc` treats as a _filename_. It tries opening and reading it, but because such file does not exist an empty result is returned.
 However, the empty input is an _invalid JSON_ (by JSON standard) - that why it's a JSON parsing error is given.
 Here how walk-path parsing error looks like:
-```bash
+```ShellSession
 bash $ <<<$JSN jtc -w[4][2][number three] -
 jtc json exception: walk_offset_missing_closure
 bash $
@@ -210,13 +210,13 @@ bash $
 
 To escape shell interpolation, either the whole argument must be quoted, or a space symbol (the former varian is preferred, but
 both will work):
-```bash
+```ShellSession
 bash $ <<<$JSN jtc -w'[4][2][number three]'
 ```
 ```json
 3
 ```
-```bash
+```ShellSession
 bash $ <<<$JSN jtc -w[4][2][number\ three]
 ```
 ```json
@@ -224,7 +224,7 @@ bash $ <<<$JSN jtc -w[4][2][number\ three]
 ```
 
 The elements within objects also could be addressed using _numerical offsets_:
-```bash
+```ShellSession
 bash $ <<<$JSN jtc -w[4][2][0]
 ```
 ```json
@@ -234,12 +234,12 @@ bash $ <<<$JSN jtc -w[4][2][0]
 of elements within _JSON objects_ are fragile**_.
 
 Say, there's a following JSON:
-```bash
+```ShellSession
 bash $ ANML='{ "ANDEAN BEAR": "Bono", "AMUR TIGER": "Shadow", "GRIZZLY BEAR": "Goofy" }'
 ```
 And we want to get get the name of `ANDEAN BEAR`. Being lazy one can do it by a _numerical offset_, assuming here that the index
 of the required entry would be `0` (indeed, it's listed first there in the object), let's see:
-```bash
+```ShellSession
 bash $ <<<$ANML jtc -w[0]
 ```
 ```json
@@ -255,7 +255,7 @@ down to the internal implementation specifics.
 
 `jtc` always rearranges all the elements within the _JSON objects_ by their keys (labels) in  the _alphabetical_ order,
 thus for `jtc` the above JSON looks like this:
-```bash
+```ShellSession
 bash $ <<<$ANML jtc
 ```
 ```json
@@ -267,7 +267,7 @@ bash $ <<<$ANML jtc
 ```
 
 That is a serious enough reason to select elements in JSON objects by their keys/labels:
-```bash
+```ShellSession
 bash $ <<<$ANML jtc -w'[ANDEAN BEAR]'
 ```
 ```json
@@ -275,7 +275,7 @@ bash $ <<<$ANML jtc -w'[ANDEAN BEAR]'
 ```
 ##
 There's a curious case, when the label matches a numerical subscript, i.e. consider:
-```bash
+```ShellSession
 bash $ <<<'{ "0": 12345, "#": "abcde"}' jtc
 ```
 ```json
@@ -286,7 +286,7 @@ bash $ <<<'{ "0": 12345, "#": "abcde"}' jtc
 ```
 
 Addressing _JSON root_ with `[0]` will return `"abcde"`:
-```bash
+```ShellSession
 bash $ <<<'{ "0": 12345, "#": "abcde"}' jtc -w[0]
 ```
 ```json
@@ -306,7 +306,7 @@ For those who are familiar with _Python addressing_, grasping this one is easy -
 
 Range subscript makes the walk-path iterable, i.e. it's like selecting multiple elements with just one _iterable walk_
 instead of specifying multiple offsets, compare:
-```bash
+```ShellSession
 bash $ <<<$JSN jtc -w[0] -w[1] -w[2]
 ```
 ```json
@@ -314,7 +314,7 @@ bash $ <<<$JSN jtc -w[0] -w[1] -w[2]
 false
 null
 ```
-```bash
+```ShellSession
 bash $ <<<$JSN jtc -w[0:3]
 ```
 ```json
@@ -332,7 +332,7 @@ while a _default_ index in the second position means: till the last value in the
 it's quite handy when we need to select only portion of the elements in the iterable either starting form its beginning, or till it's
 last element, because sometimes we might not know upfront a number of elements in the iterable.
 - select 2 elements from the beginning of the _JSON root's_  iterable:
-```bash
+```ShellSession
 bash $ <<<$JSN jtc -w[:2]
 ```
 ```json
@@ -340,7 +340,7 @@ bash $ <<<$JSN jtc -w[:2]
 false
 ```
 - select _all_ elements staring from 3rd one:
-```bash
+```ShellSession
 bash $ <<<$JSN jtc -w[2:]
 ```
 ```json
@@ -359,7 +359,7 @@ null
 
 
 when both indices are missed `[:]` then each element in the iterable will be selected (_walked_):
-```bash
+```ShellSession
 bash $ <<<$JSN jtc -w[:]
 ```
 ```json
@@ -381,7 +381,7 @@ null
 The _range indices_ (as well as any lexemes) can appear in the walk-path _any number of times_. The above example shows iterating over
 the _top iterable_ (or, the first tier) in JSON tree hierarchy, to iterate over _all_ iterables in the second tier of the JSON tree,
 do this:
-```bash
+```ShellSession
 bash $ <<<$JSN jtc -w[:][:]
 ```
 ```json
@@ -395,13 +395,13 @@ bash $ <<<$JSN jtc -w[:][:]
 \- an each element in the _top iterable_ will be _walked_ and then attempted to walk the _children_ of the walked element itself,
 one by one.
 Because first three elements are not iterable, they will not be shows (they cannot be iterated over):
-```bash
+```ShellSession
 bash $ <<<$JSN jtc -w[0][:]
 bash $
 ```
 
 If you like to see (print) both walks of the top iterable and then each of the iterable at the second tier, then provide two walk paths:
-```bash
+```ShellSession
 bash $ <<<$JSN jtc -w[:] -w[:][:]
 ```
 ```json
@@ -427,7 +427,7 @@ null
 ```
 \- Note how `jtc` _interleaves_ the walks - it puts relevant walkings in a good (relevant) order, rather than dumping results of
 the first walk and then of the second. If one prefers seeing the latter behavior, option `-n` will do the trick, compare:
-```bash
+```ShellSession
 bash $ <<<$JSN jtc -w[:] -w[:][:] -n
 ```
 ```json
@@ -455,7 +455,7 @@ null
 ##### Alternative range notation
 `[+n]` is the alternative range notation for `[n:]`, they both do exactly the same thing - walk each element in the iterable starting
 from `n`th element:
-```bash
+```ShellSession
 bash $ <<<$JSN jtc -w[+3]
 ```
 ```json
@@ -470,7 +470,7 @@ bash $ <<<$JSN jtc -w[+3]
    }
 ]
 ```
-```bash
+```ShellSession
 bash $ <<<$JSN jtc -w[3:]
 ```
 ```json
@@ -493,7 +493,7 @@ Using either of notations is a matter of personal preference and has no impact o
 Positive indices (and `0`) in the range notation (`[n:N]`) always refer to the index offset _from the beginning_ of the iterable.
 
 When both `n` and `N` are positive, naturally `N` must be > `n`, if `N` <= `n`, it'll result in a blank output:
-```bash
+```ShellSession
 bash $ <<<$JSN jtc -w[2:1]
 bash $
 bash $ <<<$JSN jtc -w[2:2]
@@ -501,7 +501,7 @@ bash $
 ```
 
 Case where `N` = `n` + 1, e.g., `[3:4]` is equal to spelling just a _numerical offset_ alone:
-```bash
+```ShellSession
 bash $ <<<$JSN jtc -w[3:4]
 ```
 ```json
@@ -509,7 +509,7 @@ bash $ <<<$JSN jtc -w[3:4]
    "pi": 3.14
 }
 ```
-```bash
+```ShellSession
 bash $ <<<$JSN jtc -w[3]
 ```
 ```json
@@ -524,7 +524,7 @@ A negative index in the _range subscript_ refers to the offset _from the end_ of
 mix and match positive and negative indices in any position.
 
 - select _last 3 elements_ from the top array:
-```bash
+```ShellSession
 bash $ <<<$JSN jtc -w[-3:]
 ```
 ```json
@@ -542,7 +542,7 @@ null
 ```
 
 - select _all_ elements in the range _from the 2nd_ till the one _before the last one_:
-```bash
+```ShellSession
 bash $ <<<$JSN jtc -w[1:-1]
 ```
 ```json
@@ -556,7 +556,7 @@ null
 ##
 When either of indices is given outside of the _actual range_ of the iterable, `jtc` tolerates it fine re-adjusting respective range
 indices properly to the beginning and the end of actual range of the iterable:
-```bash
+```ShellSession
 bash $ <<<$JSN jtc -w[-100:100]
 ```
 ```json
@@ -590,7 +590,7 @@ from the currently walked element
 
 Not sure if the definition above is easy to understand, but the concept is, so it's probably much easier to show it with the example.
 Let's see the walk path where we selected the JSON element `3`:
-```bash
+```ShellSession
 bash $ <<<$JSN jtc -w'[4][2][number three]'
 ```
 ```json
@@ -602,14 +602,14 @@ The _**walk path**_ from the _JSON root_ towards the element `3` is **`[4][2][nu
 In fact, every walk at any given step (even when it's done via _recursive search_ lexemes) internally always maintains a
 representation expressed via _subscript and literal offsets_ only.
 E.g. the same number `3` could have been selected using a _recursive search_ walk:
-```bash
+```ShellSession
 bash $ <<<$JSN jtc -w'<3>d'
 ```
 ```json
 3
 ```
 but internally, the path towards this JSON element would be built as:
-```bash
+```ShellSession
 bash $ <<<$JSN jtc -w'<3>d' -dddd 2>&1 | grep "built path vector"
 ....walk_(), built path vector: 00000004-> 00000002-> number three
 ....walk_(), finished walking: with built path vector: 00000004-> 00000002-> number three
@@ -630,7 +630,7 @@ Thus in order to select either of parents, we just need to pick a respective ind
 _Note_: `[-0]` will address the value `3` itself, so there's no much of a point to use such addressing, while indices greater _root's
 (in that example are `[-4]`, `[-5]`, etc will keep addressing the JSON root)_
 Take a look:
-```bash
+```ShellSession
 bash $ <<<$JSN jtc -w'[4][2][number three][-1]'
 ```
 ```json
@@ -638,7 +638,7 @@ bash $ <<<$JSN jtc -w'[4][2][number three][-1]'
    "number three": 3
 }
 ```
-```bash
+```ShellSession
 bash $ <<<$JSN jtc -w'[4][2][number three][-2]'
 ```
 ```json
@@ -650,7 +650,7 @@ bash $ <<<$JSN jtc -w'[4][2][number three][-2]'
    }
 ]
 ```
-```bash
+```ShellSession
 bash $ <<<$JSN jtc -w'[4][2][number three][-3]'
 ```
 ```json
@@ -679,7 +679,7 @@ Index from the root:   0    1  2      3
           walk-path: (root)[4][2][number three]
 ```
 You must get already the idea: the addressing parent off the root takes those indices:
-```bash
+```ShellSession
 bash $ <<<$JSN jtc -w'[4][2][number three][^0]'
 ```
 ```json
@@ -699,7 +699,7 @@ bash $ <<<$JSN jtc -w'[4][2][number three][^0]'
    ]
 ]
 ```
-```bash
+```ShellSession
 bash $ <<<$JSN jtc -w'[4][2][number three][^1]'
 ```
 ```json
@@ -711,7 +711,7 @@ bash $ <<<$JSN jtc -w'[4][2][number three][^1]'
    }
 ]
 ```
-```bash
+```ShellSession
 bash $ <<<$JSN jtc -w'[4][2][number three][^2]'
 ```
 ```json
@@ -719,7 +719,7 @@ bash $ <<<$JSN jtc -w'[4][2][number three][^2]'
    "number three": 3
 }
 ```
-```bash
+```ShellSession
 bash $ <<<$JSN jtc -w'[4][2][number three][^3]'
 ```
 ```json
@@ -776,7 +776,7 @@ The lexeme might be empty or hold the `namespace` where matched value will be st
 
 Examples:
 - Find an exact string value:
-```bash
+```ShellSession
 bash $ <<<$JSN jtc -w'<two>'
 ```
 ```json
@@ -784,7 +784,7 @@ bash $ <<<$JSN jtc -w'<two>'
 ```
 
 - Find a string value matching _RE_:
-```bash
+```ShellSession
 bash $ <<<$JSN jtc -w'<^t>R'
 ```
 ```json
@@ -792,7 +792,7 @@ bash $ <<<$JSN jtc -w'<^t>R'
 ```
 
 - Find the first _JSON string_ value:
-```bash
+```ShellSession
 bash $ <<<$JSN jtc -w'<>P'
 ```
 ```json
@@ -820,7 +820,7 @@ an index
 
 Some examples:
 let's work with this JSON:
-```bash
+```ShellSession
 bash $ JSS='["one", "two", ["three", "four", {"5 to 7": [ "five", "six", "seven"], "second 1": "one"  } ] ]'
 bash $ <<<$JSS jtc
 ```
@@ -844,7 +844,7 @@ bash $ <<<$JSS jtc
 ```
 
 - among all _JSON strings_ find those from 2nd till 5th inclusive:
-```bash
+```ShellSession
 bash $ <<<$JSS jtc -w'<>P1:5'
 ```
 ```json
@@ -860,7 +860,7 @@ when _directives_ covered, for now just take it: one way to set a value to the n
 So, let's repeat the last example, but now using quantifier indices references in the namespaces:
 
 - among all _JSON strings_ find those from 2nd till 5th inclusive:
-```bash
+```ShellSession
 bash $ <<<$JSS jtc -w'<Start:1>v<End:5>v <>P{Start}:{End}'
 ```
 ```json
@@ -872,7 +872,7 @@ bash $ <<<$JSS jtc -w'<Start:1>v<End:5>v <>P{Start}:{End}'
 ##
 
 - find all the string occurrences where letter `e` is present:
-```bash
+```ShellSession
 bash $ <<<$JSS jtc -w'<e>R:'
 ```
 ```json
@@ -884,7 +884,7 @@ bash $ <<<$JSS jtc -w'<e>R:'
 ```
 
 - find all the occurrences of string `"one"`:
-```bash
+```ShellSession
 bash $ <<<$JSS jtc -w'<one>:'
 ```
 ```json
@@ -899,7 +899,7 @@ In the last example, 2 instances of the string `"one"` were found. That's becaus
 only among immediate children of a current _iterable_.
 
 the JSON's root in the example is an _array_, so if we apply a non-recursive search on the root's array, only one match will be found:
-```bash
+```ShellSession
 bash $ <<<$JSS jtc -w'>one<:'
 ```
 ```json
@@ -912,7 +912,7 @@ _any_ JSON type (even atomic).
 
 The recursive search always begins from checking the currently selected (walked) entry, that's why it's possible to apply it
 even onto atomic types and match those:
-```bash
+```ShellSession
 bash $ <<<$JSS jtc -w'[0]<one>'
 ```
 ```json
@@ -930,14 +930,14 @@ bash $ <<<$JSS jtc -w'[0]<one>'
 - `<>N`, `<namespace>N` - matches any JSON numerical value (a.k.a. _JSON numerical type match_), similar to `<.*>D` but faster.
 The lexeme might be empty or hold the `namespace` where matched value will be preserved (upon a match)
 
-```bash
+```ShellSession
 bash $ <<<$JSN jtc -w'<[13]>D1:'
 ```
 ```json
 1
 3
 ```
-```bash
+```ShellSession
 bash $ <<<$JSN jtc -w'<3.14>d:'
 ```
 ```json
@@ -954,7 +954,7 @@ in the `namespace` shall it be present in the lexeme
 - `<true>b`, `<false>b` - when a _JSON boolean_ is spelled as a lexeme parameter, then it's not a _namespace_ reference,
 but rather a spelled boolean value will be matched
 
-```bash
+```ShellSession
 bash $ <<<$JSN jtc -w'<>b:'
 ```
 ```json
@@ -978,7 +978,7 @@ The others are:
 
 All of those lexemes can stay empty, or hold the _namespace_ that will be filled upon a successful match.
 
-```bash
+```ShellSession
 bash $ <<<$JSN jtc -rw'<>c:'
 ```
 ```json
@@ -992,7 +992,7 @@ bash $ <<<$JSN jtc -rw'<>c:'
 ##
 ### Arbitrary Json searches
 lexeme with the suffix `j` can match any arbitrary JSON value:
-```bash
+```ShellSession
 bash $ <<<$JSN jtc -w'<{ "pi":3.14 }>j'
 ```
 ```json
@@ -1002,7 +1002,7 @@ bash $ <<<$JSN jtc -w'<{ "pi":3.14 }>j'
 ```
 
 Even more, the parameter in the `j` lexeme can be a _templated JSON_:
-```bash
+```ShellSession
 bash $ <<<$JSN jtc -w'[4][2][0] <Nr3>v [^0] <{"pi": {Nr3}.14}>j [pi]'
 ```
 ```json
@@ -1022,7 +1022,7 @@ Obviously the `j` lexeme cannot be empty or result in an empty lexeme after temp
 
 ##
 There's another search lexeme suffix - `s` - that one will find a JSON pointed by a _namespace_:
-```bash
+```ShellSession
 bash $  <<<$JSN jtc -w'<PI:{"pi": 3.14}>v <PI>s'
 ```
 ```json
@@ -1041,7 +1041,7 @@ The lexemes cannot be empty - they point to a namespace which will be _**overwri
 to the found element (original or duplicate) once the match is found.
 
 lexemes search for original or duplicate entries of any JSONs, not necessarily atomic types, here's an example:
-```bash
+```ShellSession
 bash $ JSD='{"Orig 1": 1, "Orig 2": "two", "list": [ "three", { "dup 1": 1, "dup 2": "two", "second dup 1": 1 } ]}'
 bash $ <<<$JSD jtc
 ```
@@ -1061,7 +1061,7 @@ bash $ <<<$JSD jtc
 ```
 
 Let's see _all_ the original elements in the above JSON:
-```bash
+```ShellSession
 bash $ <<<$JSD jtc -lrw'<org>q:'
 ```
 ```json
@@ -1075,7 +1075,7 @@ bash $ <<<$JSD jtc -lrw'<org>q:'
 As you can see there were listed _all_ first seen JSON values (including the root itself)
 
 Now, let's list _all_ the duplicates:
-```bash
+```ShellSession
 bash $ <<<$JSD jtc -lrw'<dup>Q:'
 ```
 ```json
@@ -1100,7 +1100,7 @@ type of a search:
 or _addresses_ an immediate child in the _JSON iterable_ with the numerical index from the _namespace_ `NS`
 
 First two variants should not require much of a clarification, let's work with the following JSON:
-```bash
+```ShellSession
 bash $ JSL='{"One": 1, "obj": { "One": true, "Two": 2, "": 3 }, "45": "forty-five"}'
 bash $ <<<$JSL jtc
 ```
@@ -1115,7 +1115,7 @@ bash $ <<<$JSL jtc
    }
 }
 ```
-```bash
+```ShellSession
 bash $ <<<$JSL jtc -rlw'<[oO]>L:'
 ```
 ```json
@@ -1124,7 +1124,7 @@ bash $ <<<$JSL jtc -rlw'<[oO]>L:'
 "One": true
 "Two": 2
 ```
-```bash
+```ShellSession
 bash $ <<<$JSL jtc -rlw'<One>l:'
 ```
 ```json
@@ -1136,13 +1136,13 @@ bash $ <<<$JSL jtc -rlw'<One>l:'
 recursive form `<NS>t` will try matching a label from the specified namespace. The JSON type in the `NS` might be either _JSON string_,
 or _JSON numeric_, in the latter case, it's automatically converted to a _string value_ and also can match a label expressed as
 a numerical value:
-```bash
+```ShellSession
 bash $ <<<$JSL jtc -lrw'<idx:45>v <idx>t'
 ```
 ```json
 "45": "forty-five"
 ```
-```bash
+```ShellSession
 bash $ <<<$JSL jtc -lrw'<idx:"45">v <idx>t'
 ```
 ```json
@@ -1163,7 +1163,7 @@ another variant of a
 [literal subscripts](https://github.com/ldn-softdev/jtc/blob/master/Walk-path%20tutorial.md#literal-subscripts)**_.
 The latter lacks one ability - to address labels spelled as numerical value: in the above JSON, it won't be possible to address a JSON
 value `"forty-five"` via literal subscript, but using `>..<l` lexeme it is:
-```bash
+```ShellSession
 bash $ <<<$JSL jtc -rlw'[45]'
 bash $
 bash $ <<<$JSL jtc -rlw'>45<l'
@@ -1175,14 +1175,14 @@ bash $ <<<$JSL jtc -rlw'>45<l'
 The lexeme `>..<t` can do both _JSON objects_ and _arrays_:
 \- if a _namespace_ referred by the lexeme has the type _JSON string_, then it will address the label (from the namespace)
 in the JSON object:
-```bash
+```ShellSession
 bash $ <<<$JSL jtc -lw'<lbl:"45">v >lbl<t'
 ```
 ```json
 "45": "forty-five"
 ```
 \- if the lexeme's _namespace_ is set to _JSON numeric_ type, then it can address _JSON iterables_ by the index:
-```bash
+```ShellSession
 bash $ <<<$JSL jtc -lw'<idx:2">v [obj]>idx<t'
 ```
 ```json
@@ -1199,7 +1199,7 @@ of the same _JSON object_.
 Even though it's possible to pass to a parser an object that will hold non-unique labels, the JSON RFC
 ([8259](https://tools.ietf.org/html/rfc8259))
 _**does not define**_ software behavior in that regard. `jtc` in such case retains the first parsed value:
-```bash
+```ShellSession
 bash $ <<<'{"abc":1, "abc":2}' jtc
 ```
 ```json
@@ -1223,7 +1223,7 @@ addressing neighbors (sibling) of the matched entry_. I.e., the quantifier here 
 and therefore can take a _negative value_ - that is the only case when a quantifier may go negative.
 
 Observe a relative quantifier in action:
-```bash
+```ShellSession
 bash $ <<<$JSL jtc -w'[obj]'
 ```
 ```json
@@ -1233,25 +1233,25 @@ bash $ <<<$JSL jtc -w'[obj]'
    "Two": 2
 }
 ```
-```bash
+```ShellSession
 bash $ <<<$JSL jtc -lw'[obj] >One<l'
 ```
 ```json
 "One": true
 ```
-```bash
+```ShellSession
 bash $ <<<$JSL jtc -lw'[obj] >One<l-1'
 ```
 ```json
 "": 3
 ```
-```bash
+```ShellSession
 bash $ <<<$JSL jtc -lw'[obj] >One<l1'
 "Two": 2
 ````
 
 The relative quantifiers though are fully compatible with the quantifiers range-notation:
-```bash
+```ShellSession
 bash $ <<<$JSL jtc -lw'[obj] >One<l:'
 ```
 ```json
@@ -1272,7 +1272,7 @@ All form of quantifiers and search suffixes are supported, except label searches
 a label cannot be scoped by a label.
 
 For example:
-```bash
+```ShellSession
 bash $ <<<$JSL jtc -w'[One]:<org>q:'
 ```
 ```json
@@ -1294,7 +1294,7 @@ the subgroups will automatically setup respective namespaces, e.g.: the first su
 the second will do `$2` and so on. Plus, the entire match will populate the namespace `$0`.
 
 That way it's possible to extract any part(s) from the found JSON values for a later re-use.
-```bash
+```ShellSession
 bash $ <<<$JSL jtc -w'<(.*)[oO](.*)>L:' -T'{ "sub-group 1":{{$1}}, "sub-group 2":{{$2}}, "entire match":{{$0}} }'
 ```
 ```json
@@ -1359,7 +1359,7 @@ The directive `<NS>v` preserves currently walked value in the _namespace_ `NS`.
 [Many search lexemes](https://github.com/ldn-softdev/jtc/blob/master/Walk-path%20tutorial.md#json-types-searches)
 are capable of doing the same on their own, but for others, as well as for the subscripts, it's still a useful feature.
 
-```bash
+```ShellSession
 bash $ <<<$JSN jtc
 ```
 ```json
@@ -1379,7 +1379,7 @@ bash $ <<<$JSN jtc
    ]
 ]
 ```
-```bash
+```ShellSession
 bash $ <<<$JSN jtc -w'[4][0]<Idx>v[-1]>Idx<t'
 ```
 ```json
@@ -1387,7 +1387,7 @@ bash $ <<<$JSN jtc -w'[4][0]<Idx>v[-1]>Idx<t'
 ```
 
 It's fun to see how `jtc` works in a slow-mo, building a walk-path step by step, one lexeme at a time:
-```bash
+```ShellSession
 bash $ <<<$JSN jtc -w'[4]'
 ```
 ```json
@@ -1401,7 +1401,7 @@ bash $ <<<$JSN jtc -w'[4]'
 ```
 \- addressed there the 5th JSON element in the JSON root (always begin walking from the root)
 ##
-```bash
+```ShellSession
 bash $ <<<$JSN jtc -w'[4][0]'
 ```
 ```json
@@ -1409,7 +1409,7 @@ bash $ <<<$JSN jtc -w'[4][0]'
 ```
 \-  addressed the 1st JSON value in the JSON iterable (found in the prior step)
 ##
-```bash
+```ShellSession
 bash $ <<<$JSN jtc -w'[4][0]<Idx>v'
 ```
 ```json
@@ -1417,7 +1417,7 @@ bash $ <<<$JSN jtc -w'[4][0]<Idx>v'
 ```
 \- memorized a currently walked JSON in the namespace `Idx` (which is the _JSON numeric_ `1`)
 ##
-```bash
+```ShellSession
 bash $ <<<$JSN jtc -w'[4][0]<Idx>v[-1]'
 ```
 ```json
@@ -1431,7 +1431,7 @@ bash $ <<<$JSN jtc -w'[4][0]<Idx>v[-1]'
 ```
 \- stepped one level up (towards the root) from the last walked JSON
 ##
-```bash
+```ShellSession
 bash $ <<<$JSN jtc -w'[4][0]<Idx>v[-1]>Idx<t'
 ```
 ```json
@@ -1447,7 +1447,7 @@ The directive `<NS>k` functions pretty much like `<NS>v`, but instead of preserv
 its label (if currently walked element is a child of _JSON object_), or its index (if the currently walked element is a child
 of a _JSON array_):
 
-```bash
+```ShellSession
 bash $ <<<$JSN jtc
 ```
 ```json
@@ -1467,7 +1467,7 @@ bash $ <<<$JSN jtc
    ]
 ]
 ```
-```bash
+```ShellSession
 bash $ <<<$JSN jtc -w'<{"pi":3.14}>j<idx>k' -T'{idx}'
 ```
 ```json
@@ -1477,13 +1477,13 @@ bash $ <<<$JSN jtc -w'<{"pi":3.14}>j<idx>k' -T'{idx}'
 If the lexeme is _**empty**_ (`<>k`) _AND_ is the last one in the walk-path, then it does not memorize (obviously) the label/index
 in the namespace, but instead re-interprets the label as the JSON value. That way it become possible to rewrite labels in update (`-u`)
 operations, or re-use it in template interpolation.
-```bash
+```ShellSession
 bash $ <<<$JSN jtc -w'<{"pi":3.14}>j<>k'
 ```
 ```json
 3
 ```
-```bash
+```ShellSession
 bash $ <<<$JSN jtc -w'<{"pi":3.14}>j<>k' -T'{"idx": {{}}}' -r
 ```
 ```json
@@ -1499,7 +1499,7 @@ The directive `<NS>z` allows erasing the namespace `NS`. Mostly, this would be r
 _[walk branching](https://github.com/ldn-softdev/jtc/blob/master/Walk-path%20tutorial.md#walk-branching)_.
 
 For example, let's replace all even numbers in the array with their negative values:
-```bash
+```ShellSession
 bash $ <<<$'[1,2,3,4,5,6,7,8,9]' jtc -w'<Num>z[:]<>f<[02468]$>D:<Num>v' -T'-{Num}' -jr
 ```
 ```json
@@ -1507,7 +1507,7 @@ bash $ <<<$'[1,2,3,4,5,6,7,8,9]' jtc -w'<Num>z[:]<>f<[02468]$>D:<Num>v' -T'-{Num
 ```
 
 If the walk began w/o initial lexeme erasing namespace `Num`, then the whole attempt would fail:
-```bash
+```ShellSession
 bash $ <<<$'[1,2,3,4,5,6,7,8,9]' jtc -w'[:]<>f<[02468]$>D:<Num>v' -T'-{Num}' -jr
 ```
 ```json
@@ -1518,7 +1518,7 @@ bash $ <<<$'[1,2,3,4,5,6,7,8,9]' jtc -w'[:]<>f<[02468]$>D:<Num>v' -T'-{Num}' -jr
 Of course, knowing _how
 [Regex lexemes](https://github.com/ldn-softdev/jtc/blob/master/Walk-path%20tutorial.md#regex-searches)
 work_, it's possible to rewrite the walk-path in a bit more succinct way:
-```bash
+```ShellSession
 bash $ <<<$'[1,2,3,4,5,6,7,8,9]' jtc -w'<$0>z[:]<>f<[02468]$>D:' -T'-{$0}' -jr
 ```
 ```json

--- a/Walk-path tutorial.md
+++ b/Walk-path tutorial.md
@@ -1,8 +1,6 @@
-
-
 # [`jtc`](https://github.com/ldn-softdev/jtc). Walk-path easy. Tutorial (under construction)
 
-`Walk-path` is a way to telling `jtc` how input JSON must be walked. 
+`Walk-path` is a way to telling `jtc` how input JSON must be walked.
 
 1. [Walk-path Lexemes](https://github.com/ldn-softdev/jtc/blob/master/Walk-path%20tutorial.md#walk-path-Lexemes)
 2. [Subscript lexemes](https://github.com/ldn-softdev/jtc/blob/master/Walk-path%20tutorial.md#subscript-lexemes)
@@ -43,12 +41,12 @@
 ## Walk-path Lexemes
 `Walk-path` is an argument of `-w` option (but not only, other options may also accept `walk-path`s).
 
-`Walk-path` is made of _lexemes_ (optionally separated with the white spaces).  
+`Walk-path` is made of _lexemes_ (optionally separated with the white spaces).
 A _lexeme_ - is an atomic walk-step that `jtc` applies when traversing JSON tree. `jtc` always begins walking of any walk-path
 starting from the _JSON root_.
 
 If upon walking (i.e. applying _lexemes_, a.k.a. _walk-steps_) applying of a lexeme fails, such walk-path is considered to be empty
-(non-existent) and therefore not displayed. Only _successfully finished_ walk-paths will be displayed.  
+(non-existent) and therefore not displayed. Only _successfully finished_ walk-paths will be displayed.
 _In order to succeed walking a walk-path, all its lexemes must be walked successfully_
 
 There are only two types of lexemes:
@@ -136,7 +134,7 @@ If we try selecting a 2nd element from the resulted JSON (which has only single 
 will be blank:
 ```bash
 bash $ <<<$JSN jtc -w[4][2][1]
-bash $ 
+bash $
 bash $ <<<$JSN jtc -w[4][2][0]
 ```
 ```json
@@ -144,7 +142,7 @@ bash $ <<<$JSN jtc -w[4][2][0]
 ```
 ##
 _Note_: numerical offset is treated like one only if spelled like shown (`[n]`) - no white space allowed and `n` must be spelled
-as a valid number, otherwise it's treated as a 
+as a valid number, otherwise it's treated as a
 [_literal subscript_](https://github.com/ldn-softdev/jtc/blob/master/Walk-path%20tutorial.md#literal-subscripts).
 E.g.: `[ 0 ]` will address an element with the label `" 0 "`.
 
@@ -194,19 +192,19 @@ bash $ <<<$JSN jtc -w[4][2]
 bash $ <<<$JSN jtc -w[4][2][number three]
 jtc json exception: unexpected_end_of_string
 ```
-\- why? 
+\- why?
 \- it happens because of a _shell interpolation_. Shell treats space ('` `') as an argument separator, therefore option `-w`
 ends up only with partial argument, namely with `[4][2][number`, which is an invalid walk.
 
 ##
 in fact, `jtc` there complains due to a different reason: a second part of a walk (`three]`) is passed to `jtc` as a standalone argument,
-which `jtc` treats as a _filename_. It tries opening and reading it, but because such file does not exist an empty result is returned. 
-However, the empty input is an _invalid JSON_ (by JSON standard) - that why it's a JSON parsing error is given.  
+which `jtc` treats as a _filename_. It tries opening and reading it, but because such file does not exist an empty result is returned.
+However, the empty input is an _invalid JSON_ (by JSON standard) - that why it's a JSON parsing error is given.
 Here how walk-path parsing error looks like:
 ```bash
 bash $ <<<$JSN jtc -w[4][2][number three] -
 jtc json exception: walk_offset_missing_closure
-bash $ 
+bash $
 ```
 ##
 
@@ -255,10 +253,10 @@ That means that the order of elements (name/value pairs) within _JSON objects_ w
 (and not by user, like in _JSON arrays_). Some programs will retain the same order, others will reorder them - it all boils
 down to the internal implementation specifics.
 
-`jtc` always rearranges all the elements within the _JSON objects_ by their keys (labels) in  the _alphabetical_ order, 
+`jtc` always rearranges all the elements within the _JSON objects_ by their keys (labels) in  the _alphabetical_ order,
 thus for `jtc` the above JSON looks like this:
 ```bash
-bash $ <<<$ANML jtc 
+bash $ <<<$ANML jtc
 ```
 ```json
 {
@@ -278,7 +276,7 @@ bash $ <<<$ANML jtc -w'[ANDEAN BEAR]'
 ##
 There's a curious case, when the label matches a numerical subscript, i.e. consider:
 ```bash
-bash $ <<<'{ "0": 12345, "#": "abcde"}' jtc 
+bash $ <<<'{ "0": 12345, "#": "abcde"}' jtc
 ```
 ```json
 {
@@ -301,12 +299,12 @@ _NOTE_: there's a generic rule for all other types of subscripts: _If parsing of
 
 ##
 ### Range subscripts
-`[n:N]` - selects each element in the _iterable_, starting from `n`th index and ending with `N`th - 1, i.e. `N` 
+`[n:N]` - selects each element in the _iterable_, starting from `n`th index and ending with `N`th - 1, i.e. `N`
 is the index of the element following the last in the range. Both values `n` and `N` are optional and both could be omitted
 
 For those who are familiar with _Python addressing_, grasping this one is easy - it's matches Python's addressing concept entirely.
 
-Range subscript makes the walk-path iterable, i.e. it's like selecting multiple elements with just one _iterable walk_ 
+Range subscript makes the walk-path iterable, i.e. it's like selecting multiple elements with just one _iterable walk_
 instead of specifying multiple offsets, compare:
 ```bash
 bash $ <<<$JSN jtc -w[0] -w[1] -w[2]
@@ -325,10 +323,10 @@ false
 null
 ```
 ##
-#### Default range indices 
-Either of indices in the _range subscript_ `n` or `N` could be missed, then the index in the omitted position takes a _default_ value. 
+#### Default range indices
+Either of indices in the _range subscript_ `n` or `N` could be missed, then the index in the omitted position takes a _default_ value.
 
-i.e. a _default_ index in the first position means: from the very first value in the _iterable_,  
+i.e. a _default_ index in the first position means: from the very first value in the _iterable_,
 while a _default_ index in the second position means: till the last value in the _iterable_
 
 it's quite handy when we need to select only portion of the elements in the iterable either starting form its beginning, or till it's
@@ -394,12 +392,12 @@ bash $ <<<$JSN jtc -w[:][:]
    "three": 3
 }
 ```
-\- an each element in the _top iterable_ will be _walked_ and then attempted to walk the _children_ of the walked element itself, 
+\- an each element in the _top iterable_ will be _walked_ and then attempted to walk the _children_ of the walked element itself,
 one by one.
 Because first three elements are not iterable, they will not be shows (they cannot be iterated over):
 ```bash
 bash $ <<<$JSN jtc -w[0][:]
-bash $ 
+bash $
 ```
 
 If you like to see (print) both walks of the top iterable and then each of the iterable at the second tier, then provide two walk paths:
@@ -492,14 +490,14 @@ Using either of notations is a matter of personal preference and has no impact o
 
 ##
 #### Ranges with positive indices
-Positive indices (and `0`) in the range notation (`[n:N]`) always refer to the index offset _from the beginning_ of the iterable. 
+Positive indices (and `0`) in the range notation (`[n:N]`) always refer to the index offset _from the beginning_ of the iterable.
 
 When both `n` and `N` are positive, naturally `N` must be > `n`, if `N` <= `n`, it'll result in a blank output:
 ```bash
 bash $ <<<$JSN jtc -w[2:1]
-bash $ 
+bash $
 bash $ <<<$JSN jtc -w[2:2]
-bash $ 
+bash $
 ```
 
 Case where `N` = `n` + 1, e.g., `[3:4]` is equal to spelling just a _numerical offset_ alone:
@@ -578,7 +576,7 @@ null
 ```
 However, when the range is unknown, it's best to use the notation with the
 [_default range_](https://github.com/ldn-softdev/jtc/blob/master/Walk-path%20tutorial.md#default-range-indices)
-values (i.e., `[:]`) 
+values (i.e., `[:]`)
 
 ##
 ### Addressing parents
@@ -590,7 +588,7 @@ There are 2 ways to address parents:
 from the currently walked element
 - `[^n]` will do address parent(s) but offsetting it from the JSON _root_
 
-Not sure if the definition above is easy to understand, but the concept is, so it's probably much easier to show it with the example.  
+Not sure if the definition above is easy to understand, but the concept is, so it's probably much easier to show it with the example.
 Let's see the walk path where we selected the JSON element `3`:
 ```bash
 bash $ <<<$JSN jtc -w'[4][2][number three]'
@@ -601,8 +599,8 @@ bash $ <<<$JSN jtc -w'[4][2][number three]'
 The _**walk path**_ from the _JSON root_ towards the element `3` is **`[4][2][number three]`**.
 
 ##
-In fact, every walk at any given step (even when it's done via _recursive search_ lexemes) internally always maintains a 
-representation expressed via _subscript and literal offsets_ only.  
+In fact, every walk at any given step (even when it's done via _recursive search_ lexemes) internally always maintains a
+representation expressed via _subscript and literal offsets_ only.
 E.g. the same number `3` could have been selected using a _recursive search_ walk:
 ```bash
 bash $ <<<$JSN jtc -w'<3>d'
@@ -626,10 +624,10 @@ Index from the leaf:   3    2  1      0
           walk-path: (root)[4][2][number three]
 ```
 Thus in order to select either of parents, we just need to pick a respective index in the path. E.g.:
-- `[-1]` will address an immediate parent of the value `3` 
-- `[-2]` will address a parent of the parent of the value `3` 
+- `[-1]` will address an immediate parent of the value `3`
+- `[-2]` will address a parent of the parent of the value `3`
 - `[-3]` wil address the _JSON root_ itself.
-_Note_: `[-0]` will address the value `3` itself, so there's no much of a point to use such addressing, while indices greater _root's 
+_Note_: `[-0]` will address the value `3` itself, so there's no much of a point to use such addressing, while indices greater _root's
 (in that example are `[-4]`, `[-5]`, etc will keep addressing the JSON root)_
 Take a look:
 ```bash
@@ -753,9 +751,9 @@ Search lexemes allow performing various searches across JSSON tree, there are tw
  - `<expr>` - performs a _**recursive**_ search of `expr` from the currently selected JSON element
  - `>expr<` - performs a _**non-recrusive**_ search of `expr` for a currently selected _JSON iterable_
 
-A complete notation for search lexemes (both, recursive and non-recursive), look like this:  
+A complete notation for search lexemes (both, recursive and non-recursive), look like this:
 `<expr>SQ` (`>expr<SQ`), where:
-- `expr` is a content of the lexeme, depending on the _lexeme suffix_, its semantic may vary: it could be either of: 
+- `expr` is a content of the lexeme, depending on the _lexeme suffix_, its semantic may vary: it could be either of:
    - a value to match
    - a [Regular Expression](https://en.wikipedia.org/wiki/Regular_expression) to search for
    - a namespace (think of a _namespace_ as of a variable that can hold any JSON type/structure)
@@ -765,7 +763,7 @@ A complete notation for search lexemes (both, recursive and non-recursive), look
 - `Q` is a quantifier, whose function generally is analogous to the function of _numerical offset_ and _range subscripts_, but in some
 cases also might vary, as per documentation. the quantifier must also follow the suffix (if one present).
 
-Also, there's a few lexemes that look like _search lexemes_ but in fact they don't perform any type of search, 
+Also, there's a few lexemes that look like _search lexemes_ but in fact they don't perform any type of search,
 instead they apply a certain action, they are known as _directives_, those are distinguishable from the searches only by the suffix
 
 ##
@@ -773,7 +771,7 @@ instead they apply a certain action, they are known as _directives_, those are d
 `r`, `R`, `P` - these are suffixes to perform _JSON string_ searches. Suffix `r` is default and can be omitted:
 - `<text>` - searches for the occurrence of exact match of `text` in the JSON tree (off the currently walked element)
 - `<Regexp>R` - performs an RE search for the _regular expression_ `Regexp`
-- `<>P`, `<namespace>P` - matches any JSON string value (a.k.a a _JSON string type_ match), similar to `<.*>R` but faster. 
+- `<>P`, `<namespace>P` - matches any JSON string value (a.k.a a _JSON string type_ match), similar to `<.*>R` but faster.
 The lexeme might be empty or hold the `namespace` where matched value will be stored
 
 Examples:
@@ -803,8 +801,8 @@ bash $ <<<$JSN jtc -w'<>P'
 
 ##
 ### Quantifiers
-By default any search lexeme is going to find only a first match occurrence. That is facilitated by a default quantifier `0`. 
-If there's a need to find any other match instances (or range of instances) a quantifier must be given. 
+By default any search lexeme is going to find only a first match occurrence. That is facilitated by a default quantifier `0`.
+If there's a need to find any other match instances (or range of instances) a quantifier must be given.
 
 Quantifiers may be given in either of following forms:
 - `n` - search will find `n`th match
@@ -814,9 +812,9 @@ Quantifiers may be given in either of following forms:
 - `:` - search will find all matches
 
 Observe following rules applied to all forms of quantifiers:
-1) in any of the above notations indices (`n`, `N`) are zero based  
-2) both indices `n`, `N` must be positive numbers (or `0`). There's only one case where quantifier may go negative (see 
-[Relative quantifiers (`>..<l`,`>..<t`)](https://github.com/ldn-softdev/jtc/blob/master/Walk-path%20tutorial.md#relative-quantifiers))  
+1) in any of the above notations indices (`n`, `N`) are zero based
+2) both indices `n`, `N` must be positive numbers (or `0`). There's only one case where quantifier may go negative (see
+[Relative quantifiers (`>..<l`,`>..<t`)](https://github.com/ldn-softdev/jtc/blob/master/Walk-path%20tutorial.md#relative-quantifiers))
 3) either or both of indices `n`, `N` may take a form of `{Z}`, where `Z` is a namespace holding a JSON numeric value representing
 an index
 
@@ -856,7 +854,7 @@ bash $ <<<$JSS jtc -w'<>P1:5'
 "five"
 ```
 ##
-As it was mentioned, the quantifier indices may take values from the namespaces. Namespaces will be covered later, 
+As it was mentioned, the quantifier indices may take values from the namespaces. Namespaces will be covered later,
 when _directives_ covered, for now just take it: one way to set a value to the namespace is `<var:value>v`.
 
 So, let's repeat the last example, but now using quantifier indices references in the namespaces:
@@ -883,7 +881,7 @@ bash $ <<<$JSS jtc -w'<e>R:'
 "five"
 "seven"
 "one"
-``` 
+```
 
 - find all the occurrences of string `"one"`:
 ```bash
@@ -925,7 +923,7 @@ bash $ <<<$JSS jtc -w'[0]<one>'
 
 ##
 ### Numerical searches
-`d`, `D`, `N` - these are numerical searches suffixes, they share the same relevant semantics as 
+`d`, `D`, `N` - these are numerical searches suffixes, they share the same relevant semantics as
 [_string searches_](https://github.com/ldn-softdev/jtc/blob/master/Walk-path%20tutorial.md#string-searches):
 - `<number>d` - searches for the occurrence(s) of exact match of a `number` in the JSON tree
 - `<Regexp>D` - performs an RE search for the _regular expression_ `Regexp` among _JSON numericals_
@@ -976,7 +974,7 @@ The others are:
 - `<>i`: array (indexable) match, will match a _JSON array type_ (`[..]`)
 - `<>c`: container type match, will match either of _JSON iterable type_ (objects and/or arrays)
 - `<>e`: end node (leaf) match type, will match any of atomic types, or _empty_ containers (`{}`, `[]`)
-- `<>w`: wide type range match - will match _any_ JSON type/value 
+- `<>w`: wide type range match - will match _any_ JSON type/value
 
 All of those lexemes can stay empty, or hold the _namespace_ that will be filled upon a successful match.
 
@@ -1019,8 +1017,8 @@ That was the first complex walk-path shown, so, let's break it down:
 the resulted JSON (which will be `{"pi": 3.14}`)
 - `[pi]` will address the value in found JSON by the label offset, resulting in the final value `3.14`
 
-Obviously the `j` lexeme cannot be empty or result in an empty lexeme after template interpolation 
-(as the empty space is not a valid JSON, as per spec). 
+Obviously the `j` lexeme cannot be empty or result in an empty lexeme after template interpolation
+(as the empty space is not a valid JSON, as per spec).
 
 ##
 There's another search lexeme suffix - `s` - that one will find a JSON pointed by a _namespace_:
@@ -1031,21 +1029,21 @@ bash $  <<<$JSN jtc -w'<PI:{"pi": 3.14}>v <PI>s'
 {
    "pi": 3.14
 }
-bash $ 
+bash $
 ```
 
 The `s` lexeme also cannot be empty (it always must point to some namespace).
 
 ##
 ### Original and Duplicate searches
-`q` and `Q` lexemes allow finding original (first time seen) and duplicate elements respectively within the selected (walked) JSON tree. 
+`q` and `Q` lexemes allow finding original (first time seen) and duplicate elements respectively within the selected (walked) JSON tree.
 The lexemes cannot be empty - they point to a namespace which will be _**overwritten**_ during the search and will be set
 to the found element (original or duplicate) once the match is found.
 
 lexemes search for original or duplicate entries of any JSONs, not necessarily atomic types, here's an example:
 ```bash
-bash $ JSD='{"Orig 1": 1, "Orig 2": "two", "list": [ "three", { "dup 1": 1, "dup 2": "two", "second dup 1": 1 } ]}' 
-bash $ <<<$JSD jtc 
+bash $ JSD='{"Orig 1": 1, "Orig 2": "two", "list": [ "three", { "dup 1": 1, "dup 2": "two", "second dup 1": 1 } ]}'
+bash $ <<<$JSD jtc
 ```
 ```json
 {
@@ -1135,7 +1133,7 @@ bash $ <<<$JSL jtc -rlw'<One>l:'
 ````
 
 ##
-recursive form `<NS>t` will try matching a label from the specified namespace. The JSON type in the `NS` might be either _JSON string_, 
+recursive form `<NS>t` will try matching a label from the specified namespace. The JSON type in the `NS` might be either _JSON string_,
 or _JSON numeric_, in the latter case, it's automatically converted to a _string value_ and also can match a label expressed as
 a numerical value:
 ```bash
@@ -1155,10 +1153,10 @@ All other _JSON types_ in the `NS` will be ignored, such search will always retu
 ##
 
 #### Non-recursive behavior of label lexemes
-Normally, a non-recursive search will try matching a value among immediate children of the _JSON iterable_. 
-But for matching a label or index, the actual search (i.e., iterating over children of an iterable) is a superfluous task:  
-indeed, when we want to match a value by a label (in a _JSON object_) or by an index (in a _JSON array_), we should be able 
-to do so just by addressing them.  
+Normally, a non-recursive search will try matching a value among immediate children of the _JSON iterable_.
+But for matching a label or index, the actual search (i.e., iterating over children of an iterable) is a superfluous task:
+indeed, when we want to match a value by a label (in a _JSON object_) or by an index (in a _JSON array_), we should be able
+to do so just by addressing them.
 
 The non-recursive lexeme `>..<l` can match/address labels in _JSON objects_ only. _**That makes it (with a default quantifier) just
 another variant of a
@@ -1167,14 +1165,14 @@ The latter lacks one ability - to address labels spelled as numerical value: in 
 value `"forty-five"` via literal subscript, but using `>..<l` lexeme it is:
 ```bash
 bash $ <<<$JSL jtc -rlw'[45]'
-bash $ 
+bash $
 bash $ <<<$JSL jtc -rlw'>45<l'
 ```
 ```json
 "45": "forty-five"
 ```
 
-The lexeme `>..<t` can do both _JSON objects_ and _arrays_:  
+The lexeme `>..<t` can do both _JSON objects_ and _arrays_:
 \- if a _namespace_ referred by the lexeme has the type _JSON string_, then it will address the label (from the namespace)
 in the JSON object:
 ```bash
@@ -1193,12 +1191,12 @@ bash $ <<<$JSL jtc -lw'<idx:2">v [obj]>idx<t'
 
 ##
 #### Relative quantifiers
-There's another feature of how these lexemes operate. Think of a quantifier instance for the lexemes: 
-any _parsed_ objects will hold only 1 unique label - there cannot be two equal labels among immediate children 
-of the same _JSON object_. 
+There's another feature of how these lexemes operate. Think of a quantifier instance for the lexemes:
+any _parsed_ objects will hold only 1 unique label - there cannot be two equal labels among immediate children
+of the same _JSON object_.
 
 ##
-Even though it's possible to pass to a parser an object that will hold non-unique labels, the JSON RFC 
+Even though it's possible to pass to a parser an object that will hold non-unique labels, the JSON RFC
 ([8259](https://tools.ietf.org/html/rfc8259))
 _**does not define**_ software behavior in that regard. `jtc` in such case retains the first parsed value:
 ```bash
@@ -1209,16 +1207,16 @@ bash $ <<<'{"abc":1, "abc":2}' jtc
    "abc": 1
 }
 ```
-_NOTE_: holding two non-unique labels would render such _JSON object_ non-addressable: indeed, in the above JSON, 
+_NOTE_: holding two non-unique labels would render such _JSON object_ non-addressable: indeed, in the above JSON,
 if the object were to hold both values, which value then to select when addressed by the label `"abc"`?
 ##
 
 Getting back to the quantifiers: _any parsed objects will hold only **one** unique label, and so does array with its indices_. If so,
 the usual semantic of quantifiers as a search instance in lexemes `>..<l` and `>..>t` is moot: we know that in the _parsed_ object
-cannot be a second, third, forth (and so on) the same label, there can be only one. The same applies to arrays: there can be only one 
+cannot be a second, third, forth (and so on) the same label, there can be only one. The same applies to arrays: there can be only one
 unique index in there, thus only instance `0` (the first and the only instance) makes sense.
 
-Thus, a usual semantic of quantifier as a _match instance_ (except instance `0`) in these lexemes is meaningless. 
+Thus, a usual semantic of quantifier as a _match instance_ (except instance `0`) in these lexemes is meaningless.
 
 Therefore it was overloaded with a different and quite handy one: _a quantifier in these non-recursive lexemes allows
 addressing neighbors (sibling) of the matched entry_. I.e., the quantifier here becomes _**relative**_ (to the matched entry)
@@ -1241,7 +1239,7 @@ bash $ <<<$JSL jtc -lw'[obj] >One<l'
 ```json
 "One": true
 ```
-```bash 
+```bash
 bash $ <<<$JSL jtc -lw'[obj] >One<l-1'
 ```
 ```json
@@ -1252,7 +1250,7 @@ bash $ <<<$JSL jtc -lw'[obj] >One<l1'
 "Two": 2
 ````
 
-The relative quantifiers though are fully compatible with the quantifiers range-notation: 
+The relative quantifiers though are fully compatible with the quantifiers range-notation:
 ```bash
 bash $ <<<$JSL jtc -lw'[obj] >One<l:'
 ```
@@ -1264,12 +1262,12 @@ bash $ <<<$JSL jtc -lw'[obj] >One<l:'
 
 ##
 ### Scoped searches
-When you would like to perform a search but only among values under a specific _label_, it's known as a _scoped search_. 
-The syntax for a scoped search is rather symple: a 
-[literal offset](https://github.com/ldn-softdev/jtc/blob/master/Walk-path%20tutorial.md#literal-subscripts) is appeded wtih the 
-[search lexeme](https://github.com/ldn-softdev/jtc/blob/master/Walk-path%20tutorial.md#search-lexemes) over colon `:`, 
-e.g.:  
-`[some label]:<search lexeme>`  
+When you would like to perform a search but only among values under a specific _label_, it's known as a _scoped search_.
+The syntax for a scoped search is rather symple: a
+[literal offset](https://github.com/ldn-softdev/jtc/blob/master/Walk-path%20tutorial.md#literal-subscripts) is appeded wtih the
+[search lexeme](https://github.com/ldn-softdev/jtc/blob/master/Walk-path%20tutorial.md#search-lexemes) over colon `:`,
+e.g.:
+`[some label]:<search lexeme>`
 All form of quantifiers and search suffixes are supported, except label searches: `l`, `L` and `t` - understandably,
 a label cannot be scoped by a label.
 
@@ -1292,7 +1290,7 @@ All search lexemes supporting _regex_ based searching have been already covered:
 they support (RE) matching of _strings_, _labels_ and _numerical_ JSON values respectively.
 
 There's one more aspect to it though: the _regular expression_ also support _sub-groups_. Upon a successful match,
-the subgroups will automatically setup respective namespaces, e.g.: the first subgroup will populate a namespace `$1`, 
+the subgroups will automatically setup respective namespaces, e.g.: the first subgroup will populate a namespace `$1`,
 the second will do `$2` and so on. Plus, the entire match will populate the namespace `$0`.
 
 That way it's possible to extract any part(s) from the found JSON values for a later re-use.
@@ -1329,27 +1327,27 @@ There're few lexemes that look like searches but they do not do any searching/ma
 onto the currently walked JSONs elements or paths. They are known as _directives_. Directives are distinguishable from the search
 lexemes only by the suffix.
 
-Directives are typically agnostic to recursive or non-recursive forms of spelling, except one - `F`, 
-where the spelling has a semantical meaning. Also, the directives do not support quantifiers (the quantifiers are parsed, 
+Directives are typically agnostic to recursive or non-recursive forms of spelling, except one - `F`,
+where the spelling has a semantical meaning. Also, the directives do not support quantifiers (the quantifiers are parsed,
 but silently ignored).
 
 ##
 ##### Namespaces:
-_Namespace_ is a way to facilitate _variables_ in `jtc`. The _namespace_ is implemented as a container (in the currently processed 
+_Namespace_ is a way to facilitate _variables_ in `jtc`. The _namespace_ is implemented as a container (in the currently processed
 JSON) that holds all (sub) JSON values preserved during waling a walk-path.
 
 The JSON values found in the _namespace_ could be re-used later either during the _interpolation_, or in other lexemes of the same
 walk or in different (subsequent) walks.
 
-The namespace could be populated (setup) by a lexeme either from currently walked JSON element, or with an _**arbitrary**_ JSON value 
+The namespace could be populated (setup) by a lexeme either from currently walked JSON element, or with an _**arbitrary**_ JSON value
 (in the lexeme). e.g.:
 
-In this walk-path example a search lexeme `a` will find (recursively) the first occurrence of any _atomic JSON_ and will 
-populate the namespace _Atomic_ with a found JSON element:  
-`-w'<Atomic>a'`  
+In this walk-path example a search lexeme `a` will find (recursively) the first occurrence of any _atomic JSON_ and will
+populate the namespace _Atomic_ with a found JSON element:
+`-w'<Atomic>a'`
 In this walk-path example, the same search lexeme will populate the namespace _Atomic_ with the empty JSON array `[]`
-instead of a found atomic JSON:  
-`-w'<Atomic:[]>a'`  
+instead of a found atomic JSON:
+`-w'<Atomic:[]>a'`
 
 The ability (and the form) to setup an arbitrary JSON value is _universal_ for all lexemes (and directives)  that are capable
 of preserving values in the namespace.
@@ -1357,7 +1355,7 @@ of preserving values in the namespace.
 
 ##
 #### Preserve a currently walked value in the namespace
-The directive `<NS>v` preserves currently walked value in the _namespace_ `NS`. 
+The directive `<NS>v` preserves currently walked value in the _namespace_ `NS`.
 [Many search lexemes](https://github.com/ldn-softdev/jtc/blob/master/Walk-path%20tutorial.md#json-types-searches)
 are capable of doing the same on their own, but for others, as well as for the subscripts, it's still a useful feature.
 
@@ -1401,7 +1399,7 @@ bash $ <<<$JSN jtc -w'[4]'
    }
 ]
 ```
-\- addressed there the 5th JSON element in the JSON root (always begin walking from the root)  
+\- addressed there the 5th JSON element in the JSON root (always begin walking from the root)
 ##
 ```bash
 bash $ <<<$JSN jtc -w'[4][0]'
@@ -1409,7 +1407,7 @@ bash $ <<<$JSN jtc -w'[4][0]'
 ```json
 1
 ```
-\-  addressed the 1st JSON value in the JSON iterable (found in the prior step)  
+\-  addressed the 1st JSON value in the JSON iterable (found in the prior step)
 ##
 ```bash
 bash $ <<<$JSN jtc -w'[4][0]<Idx>v'
@@ -1417,7 +1415,7 @@ bash $ <<<$JSN jtc -w'[4][0]<Idx>v'
 ```json
 1
 ```
-\- memorized a currently walked JSON in the namespace `Idx` (which is the _JSON numeric_ `1`)  
+\- memorized a currently walked JSON in the namespace `Idx` (which is the _JSON numeric_ `1`)
 ##
 ```bash
 bash $ <<<$JSN jtc -w'[4][0]<Idx>v[-1]'
@@ -1431,7 +1429,7 @@ bash $ <<<$JSN jtc -w'[4][0]<Idx>v[-1]'
    }
 ]
 ```
-\- stepped one level up (towards the root) from the last walked JSON  
+\- stepped one level up (towards the root) from the last walked JSON
 ##
 ```bash
 bash $ <<<$JSN jtc -w'[4][0]<Idx>v[-1]>Idx<t'
@@ -1450,7 +1448,7 @@ its label (if currently walked element is a child of _JSON object_), or its inde
 of a _JSON array_):
 
 ```bash
-bash $ <<<$JSN jtc 
+bash $ <<<$JSN jtc
 ```
 ```json
 [
@@ -1476,11 +1474,11 @@ bash $ <<<$JSN jtc -w'<{"pi":3.14}>j<idx>k' -T'{idx}'
 3
 ```
 
-If the lexeme is _**empty**_ (`<>k`) _AND_ is the last one in the walk-path, then it does not memorize (obviously) the label/index 
+If the lexeme is _**empty**_ (`<>k`) _AND_ is the last one in the walk-path, then it does not memorize (obviously) the label/index
 in the namespace, but instead re-interprets the label as the JSON value. That way it become possible to rewrite labels in update (`-u`)
 operations, or re-use it in template interpolation.
 ```bash
-bash $ <<<$JSN jtc -w'<{"pi":3.14}>j<>k' 
+bash $ <<<$JSN jtc -w'<{"pi":3.14}>j<>k'
 ```
 ```json
 3
@@ -1490,14 +1488,14 @@ bash $ <<<$JSN jtc -w'<{"pi":3.14}>j<>k' -T'{"idx": {{}}}' -r
 ```
 ```json
 { "idx": 3 }
-``` 
+```
 The described effect occurs only if the empty `<>k` lexeme appears the last in the walk-path, if the lexeme appears somewhere in the
 middle of the walk-path, the lexeme is completely meaningless in that form and has no effect at all.
 
 
 ##
 ### Erase namespace
-The directive `<NS>z` allows erasing the namespace `NS`. Mostly, this would be required when used together with 
+The directive `<NS>z` allows erasing the namespace `NS`. Mostly, this would be required when used together with
 _[walk branching](https://github.com/ldn-softdev/jtc/blob/master/Walk-path%20tutorial.md#walk-branching)_.
 
 For example, let's replace all even numbers in the array with their negative values:
@@ -1530,38 +1528,14 @@ bash $ <<<$'[1,2,3,4,5,6,7,8,9]' jtc -w'<$0>z[:]<>f<[02468]$>D:' -T'-{$0}' -jr
 ##
 ### Walk branching
 Normally, all the lexemes in the _walk-path_ are contatenated with the logical operator _AND_ (i.e., a walk is suscessful only
-if _all_ lexemes are).  
-Directives `<..>f`, `<..>F` and `><F` introduce walk branching (the easiest way to think of it as of `if .. else ..`), 
+if _all_ lexemes are).
+Directives `<..>f`, `<..>F` and `><F` introduce walk branching (the easiest way to think of it as of `if .. else ..`),
 i.e. they facilitate a control-flow logic of the walk-path exectution.
 
 _Note_: the direcitve `F` is sensitive to the lexeme spelling (a recursive vs a non-recursive form) and provides different
-reactions for each of the form (this is the only directive so far that is sensitive to the lexeme encasement, all others are not). 
+reactions for each of the form (this is the only directive so far that is sensitive to the lexeme encasement, all others are not).
 
 ##
 #### Fail-safe directive
 `<>f` is a _fail-safe_ directive (facilitating `if` part). Once walked, it memorizes the internally maintained path to the
 currently walked JSON element and reinstate it, shall the walk _past_ `<>f` directive fails:
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-


### PR DESCRIPTION
This pull request only modifies the documentation.

I've taken the liberty to remove all trailing whitespaces from the markdown files and fixed 3 occurrences of 4 backticks to 3. The actual change that I was intending to submit is to add a language specifier to all code blocks, so that github renders these appropriately.